### PR TITLE
feat: Add configurable collab url and basic tls support

### DIFF
--- a/lib/Listener/LoadViewerListener.php
+++ b/lib/Listener/LoadViewerListener.php
@@ -11,12 +11,22 @@ declare(strict_types=1);
 namespace OCA\Whiteboard\Listener;
 
 use OCA\Viewer\Event\LoadViewer;
+use OCA\Whiteboard\AppInfo\Application;
+use OCP\AppFramework\Services\IInitialState;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
+use OCP\IAppConfig;
+use OCP\IConfig;
 use OCP\Util;
 
 /** @template-implements IEventListener<LoadViewer|Event> */
 class LoadViewerListener implements IEventListener {
+	public function __construct(
+		private IInitialState $initialState,
+		private IConfig $config,
+	) {
+	}
+
 	public function handle(Event $event): void {
 		if (!($event instanceof LoadViewer)) {
 			return;
@@ -25,5 +35,9 @@ class LoadViewerListener implements IEventListener {
 		Util::addScript('whiteboard', 'whiteboard-main');
 		Util::addStyle('whiteboard', 'whiteboard-main');
 
+		$this->initialState->provideInitialState(
+			'collabBackendUrl',
+			$this->config->getAppValue(Application::APP_ID, 'collabBackendUrl', '')
+		);
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@nextcloud/axios": "^2.5.0",
         "@nextcloud/event-bus": "^3.2.0",
         "@nextcloud/files": "^3.2.1",
+        "@nextcloud/initial-state": "^2.2.0",
         "@nextcloud/l10n": "^3.0.0",
         "@nextcloud/router": "^3.0.1",
         "express": "^4.19.2",
@@ -1500,6 +1501,15 @@
         "@nextcloud/typings": "^1.7.0",
         "core-js": "^3.6.4"
       },
+      "engines": {
+        "node": "^20.0.0",
+        "npm": "^10.0.0"
+      }
+    },
+    "node_modules/@nextcloud/initial-state": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/initial-state/-/initial-state-2.2.0.tgz",
+      "integrity": "sha512-cDW98L5KGGgpS8pzd+05304/p80cyu8U2xSDQGa+kGPTpUFmCbv2qnO5WrwwGTauyjYijCal2bmw82VddSH+Pg==",
       "engines": {
         "node": "^20.0.0",
         "npm": "^10.0.0"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@nextcloud/axios": "^2.5.0",
     "@nextcloud/event-bus": "^3.2.0",
     "@nextcloud/files": "^3.2.1",
+    "@nextcloud/initial-state": "^2.2.0",
     "@nextcloud/l10n": "^3.0.0",
     "@nextcloud/router": "^3.0.1",
     "express": "^4.19.2",

--- a/src/collaboration/collab.ts
+++ b/src/collaboration/collab.ts
@@ -5,6 +5,7 @@ import { io } from 'socket.io-client'
 import { restoreElements } from '@excalidraw/excalidraw'
 import { throttle } from 'lodash'
 import { hashElementsVersion, reconcileElements } from './util'
+import { loadState } from '@nextcloud/initial-state'
 
 export class Collab {
 
@@ -27,7 +28,9 @@ export class Collab {
 
 	startCollab() {
 		if (this.portal.socket) return
-		this.portal.open(io('nextcloud.local:3002/'))
+
+		const collabBackendUrl = loadState('whiteboard', 'collabBackendUrl', 'nextcloud.local:3002')
+		this.portal.open(io(collabBackendUrl))
 		this.excalidrawAPI.onChange(this.onChange)
 	}
 

--- a/websocket_server/index.js
+++ b/websocket_server/index.js
@@ -1,22 +1,33 @@
 import express from 'express'
 import http from 'http'
+import https from 'https'
 import { Server as SocketIO } from 'socket.io'
 import fetch from 'node-fetch'
+import * as fs from 'node:fs'
+
+
+const nextcloudUrl = process.env.NEXTCLOUD_URL || 'http://nextcloud.local'
+const port = process.env.PORT || 3002
+
+const tls = process.env.TLS || false
+const key = process.env.TLS_KEY || undefined
+const cert = process.env.TLS_CERT || undefined
 
 const app = express()
-
-const port = process.env.PORT || 3002
 
 app.get('/', (req, res) => {
 	res.send('Excalidraw collaboration server is up :)')
 })
 
-const server = http.createServer(app)
+const server = (tls ? https : http).createServer({
+	key: key ? fs.readFileSync(key) : undefined,
+	cert: cert ? fs.readFileSync(cert) : undefined,
+}, app)
 
 let roomDataStore = {}
 
 const getRoomDataFromFile = async (roomID) => {
-	const response = await fetch(`http://nextcloud.local/index.php/apps/whiteboard/${roomID}`, {
+	const response = await fetch(`${nextcloudUrl}/index.php/apps/whiteboard/${roomID}`, {
 		headers: {
 			'Authorization': 'Basic ' + Buffer.from('admin:admin').toString('base64'),
 		},
@@ -46,7 +57,7 @@ const saveRoomDataToFile = async (roomID, data) => {
 	const body = JSON.stringify({ data: { elements: data } })
 
 	try {
-		await fetch(`http://nextcloud.local/index.php/apps/whiteboard/${roomID}`, {
+		await fetch(`${nextcloudUrl}/index.php/apps/whiteboard/${roomID}`, {
 			method: 'PUT',
 			headers: {
 				'Authorization': 'Basic ' + Buffer.from('admin:admin').toString('base64'),


### PR DESCRIPTION
Makes testing for me a bit easier with HTTPS locally and more flexible as we might need it anyways

Collab backend URL can be configured with
```
occ config:app:set whiteboard collabBackendUrl --value "nextcloud.local:3003"
```

Configurable Nextcloud callback URL and TLS:
```
TLS=1 TLS_CERT=/Users/julius/repos/nextcloud/nc-dev/data/ssl/nextcloud.local.crt TLS_KEY=/Users/julius/repos/nextcloud/nc-dev/data/ssl/nextcloud.local.key NEXTCLOUD_URL=https://nextcloud.local PORT=3003 npm run server:start
```