### PR TITLE
fix: Include composer dependencies in the release bundle

### DIFF
--- a/krankerl.toml
+++ b/krankerl.toml
@@ -1,5 +1,6 @@
 [package]
 before_cmds = [
+    'composer install --no-dev',
     'npm ci',
-	'npm run build'
+    'npm run build'
 ]


### PR DESCRIPTION
Seems that was missed and not noticed on previous manual deployents