### PR TITLE
fix: Properly set URL for settings check if running in a subdirectory

### DIFF
--- a/src/settings/Settings.vue
+++ b/src/settings/Settings.vue
@@ -81,8 +81,10 @@ export default {
 			await this.verifyConnection(data)
 		},
 		async verifyConnection(data) {
-			const path = '/socket.io'
-			const socket = io(this.serverUrl, {
+			const url = new URL(this.serverUrl)
+			const path = url.pathname.replace(/\/$/, '') + '/socket.io'
+
+			const socket = io(url.origin, {
 				path,
 				withCredentials: true,
 				auth: {


### PR DESCRIPTION
Small fix for making the settings check work properly if the whiteboard backend is mapped to a path through the reverse proxy config.