### PR TITLE
fix: Make template file creator registration compatible with 28/29

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -20,8 +20,11 @@ use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
+use OCP\Files\Template\ITemplateManager;
 use OCP\Files\Template\RegisterTemplateCreatorEvent;
+use OCP\IL10N;
 use OCP\Security\CSP\AddContentSecurityPolicyEvent;
+use OCP\Util;
 
 /**
  * @psalm-suppress UndefinedClass
@@ -44,6 +47,13 @@ class Application extends App implements IBootstrap {
 	}
 
 	public function boot(IBootContext $context): void {
-
+		[$major] = Util::getVersion();
+		if ($major < 30) {
+			$context->injectFn(function (ITemplateManager $templateManager, IL10N $l10n) use ($major) {
+				$templateManager->registerTemplateFileCreator(function () use ($l10n) {
+					return RegisterTemplateCreatorListener::getTemplateFileCreator($l10n);
+				});
+			});
+		}
 	}
 }

--- a/lib/Listener/RegisterTemplateCreatorListener.php
+++ b/lib/Listener/RegisterTemplateCreatorListener.php
@@ -32,11 +32,15 @@ final class RegisterTemplateCreatorListener implements IEventListener {
 
 
 		$event->getTemplateManager()->registerTemplateFileCreator(function () {
-			$whiteboard = new TemplateFileCreator(Application::APP_ID, $this->l10n->t('New whiteboard'), '.whiteboard');
-			$whiteboard->addMimetype('application/vnd.excalidraw+json');
-			$whiteboard->setIconSvgInline(file_get_contents(__DIR__ . '/../../img/app-filetype.svg'));
-			$whiteboard->setActionLabel($this->l10n->t('Create new whiteboard'));
-			return $whiteboard;
+			return self::getTemplateFileCreator($this->l10n);
 		});
+	}
+
+	public static function getTemplateFileCreator(IL10N $l10n): TemplateFileCreator {
+		$whiteboard = new TemplateFileCreator(Application::APP_ID, $l10n->t('New whiteboard'), '.whiteboard');
+		$whiteboard->addMimetype('application/vnd.excalidraw+json');
+		$whiteboard->setIconSvgInline(file_get_contents(__DIR__ . '/../../img/app-filetype.svg'));
+		$whiteboard->setActionLabel($l10n->t('Create new whiteboard'));
+		return $whiteboard;
 	}
 }


### PR DESCRIPTION
Otherwise the entry to create new files will not show up on older releases as the event for it was only introduced in 30.