### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ RewriteRule ^/?whiteboard/(.*) "ws://localhost:3002/$1" [P,L]
 #### Nginx
 
 ```
-location /whiteboard/ {
+location /socket.io/ {
 	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	proxy_set_header Host $host;
 	


### PR DESCRIPTION
It should be /socket.io/ for reverse proxy in nginx.

I have tried in my app and having an issue with /whiteboard/ but it works fine with /socket.io/

or update the code to hit the URL /whiteboard instead of /socket.io