### PR TITLE
fix: Properly handle metrics aggregation with room data

### DIFF
--- a/websocket_server/LRUCacheStrategy.js
+++ b/websocket_server/LRUCacheStrategy.js
@@ -7,6 +7,7 @@
 
 import StorageStrategy from './StorageStrategy.js'
 import { LRUCache } from 'lru-cache'
+import Room from './Room.js'
 
 export default class LRUCacheStrategy extends StorageStrategy {
 
@@ -52,7 +53,9 @@ export default class LRUCacheStrategy extends StorageStrategy {
 	}
 
 	getRooms() {
-		return this.cache
+		const rooms = Array.from(this.cache.values()).filter((room) => room instanceof Room)
+
+		return rooms
 	}
 
 }

--- a/websocket_server/RedisStrategy.js
+++ b/websocket_server/RedisStrategy.js
@@ -95,7 +95,7 @@ export default class RedisStrategy extends StorageStrategy {
 			const rooms = new Map()
 			for (const key of keys) {
 				const room = await this.get(key)
-				if (room) rooms.set(key, room)
+				if (room && !key.startsWith('token:') && !key.startsWith('socket:')) rooms.set(key, room)
 			}
 			return rooms
 		} catch (error) {

--- a/websocket_server/SystemMonitor.js
+++ b/websocket_server/SystemMonitor.js
@@ -33,17 +33,17 @@ export default class SystemMonitor {
 	getRoomStats(rooms) {
 		return {
 			activeRooms: rooms.size,
-			totalUsers: Array.from(rooms.values()).reduce((sum, room) => sum + Object.keys(room.users).length, 0),
+			totalUsers: Array.from(rooms.values()).reduce((sum, room) => sum + Object.keys(room?.users ?? {}).length, 0),
 			totalDataSize: this.formatBytes(Array.from(rooms.values()).reduce((sum, room) => sum + (room.data ? JSON.stringify(room.data).length : 0), 0)),
 		}
 	}
 
 	getRoomsData(rooms) {
-		return Array.from(rooms.entries()).map(([roomId, room]) => ({
-			id: roomId,
+		return Array.from(rooms).map((room) => ({
+			id: room.id,
 			users: Object.keys(room.users),
 			lastEditedUser: room.lastEditedUser,
-			lastActivity: new Date(room.lastActivity).toISOString(),
+			lastActivity: room.lastActivity ? new Date(room.lastActivity).toISOString() : null,
 			dataSize: this.formatBytes(JSON.stringify(room.data).length),
 			data: room.data, // Be cautious with this if the data is very large
 		}))


### PR DESCRIPTION
- Join a room
- Requets the metrics endpoint

## Before

```
TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at file:///app/websocket_server/SystemMonitor.js:36:78
    at Array.reduce (<anonymous>)
    at SystemMonitor.getRoomStats (file:///app/websocket_server/SystemMonitor.js:36:43)
    at SystemMonitor.getSystemOverview (file:///app/websocket_server/SystemMonitor.js:16:20)
    at PrometheusDataManager.updateMetrics (file:///app/websocket_server/PrometheusDataManager.js:37:39)
    at AppManager.metricsHandler (file:///app/websocket_server/AppManager.js:36:23)
    at Layer.handleRequest (/app/node_modules/router/lib/layer.js:145:17)
    at next (/app/node_modules/router/lib/route.js:159:13)
    at Route.dispatch (/app/node_modules/router/lib/route.js:119:3)
```

## After

No more error

## Follow up

- [ ] Cleanup storage manager to properly prefix rooms as now also other data is stored (token/socket data)