### PR TITLE
[main] Fix npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9932,9 +9932,9 @@
       "license": "MIT"
     },
     "node_modules/node-stdlib-browser": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/node-stdlib-browser/-/node-stdlib-browser-1.2.0.tgz",
-      "integrity": "sha512-VSjFxUhRhkyed8AtLwSCkMrJRfQ3e2lGtG3sP6FEgaLKBBbxM/dLfjRe1+iLhjvyLFW3tBQ8+c0pcOtXGbAZJg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/node-stdlib-browser/-/node-stdlib-browser-1.2.1.tgz",
+      "integrity": "sha512-dZezG3D88Lg22DwyjsDuUs7cCT/XGr8WwJgg/S3ZnkcWuPet2Tt/W1d2Eytb1Z73JpZv+XVCDI5TWv6UMRq0Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9962,7 +9962,7 @@
         "string_decoder": "^1.0.0",
         "timers-browserify": "^2.0.4",
         "tty-browserify": "0.0.1",
-        "url": "^0.11.0",
+        "url": "^0.11.4",
         "util": "^0.12.4",
         "vm-browserify": "^1.0.1"
       },


### PR DESCRIPTION
# Audit report

This audit fix resolves 12 of the total 16 vulnerabilities found in your project.

## Updated dependencies
* [@nextcloud/dialogs](#user-content-\@nextcloud\/dialogs)
* [@nextcloud/files](#user-content-\@nextcloud\/files)
* [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
* [@nextcloud/vue](#user-content-\@nextcloud\/vue)
* [browserify-sign](#user-content-browserify-sign)
* [create-ecdh](#user-content-create-ecdh)
* [crypto-browserify](#user-content-crypto-browserify)
* [elliptic](#user-content-elliptic)
* [node-gettext](#user-content-node-gettext)
* [node-stdlib-browser](#user-content-node-stdlib-browser)
* [vite-plugin-node-polyfills](#user-content-vite-plugin-node-polyfills)
* [vue-tsc](#user-content-vue-tsc)
## Fixed vulnerabilities

### @nextcloud/dialogs <a href="#user-content-\@nextcloud\/dialogs" id="\@nextcloud\/dialogs">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/files](#user-content-\@nextcloud\/files)
  * [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
  * [@nextcloud/vue](#user-content-\@nextcloud\/vue)
* Affected versions: >=2.0.0
* Package usage:
  * `node_modules/@nextcloud/dialogs`

### @nextcloud/files <a href="#user-content-\@nextcloud\/files" id="\@nextcloud\/files">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
* Affected versions: >=1.1.0
* Package usage:
  * `node_modules/@nextcloud/files`

### @nextcloud/l10n <a href="#user-content-\@nextcloud\/l10n" id="\@nextcloud\/l10n">#</a>
* Caused by vulnerable dependency:
  * [node-gettext](#user-content-node-gettext)
* Affected versions: >=1.1.0
* Package usage:
  * `node_modules/@nextcloud/l10n`

### @nextcloud/vue <a href="#user-content-\@nextcloud\/vue" id="\@nextcloud\/vue">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
* Affected versions: >=1.4.0
* Package usage:
  * `node_modules/@nextcloud/vue`

### browserify-sign <a href="#user-content-browserify-sign" id="browserify-sign">#</a>
* Caused by vulnerable dependency:
  * [elliptic](#user-content-elliptic)
* Affected versions: >=2.4.0
* Package usage:
  * `node_modules/browserify-sign`

### create-ecdh <a href="#user-content-create-ecdh" id="create-ecdh">#</a>
* Caused by vulnerable dependency:
  * [elliptic](#user-content-elliptic)
* Affected versions: *
* Package usage:
  * `node_modules/create-ecdh`

### crypto-browserify <a href="#user-content-crypto-browserify" id="crypto-browserify">#</a>
* Caused by vulnerable dependency:
  * [browserify-sign](#user-content-browserify-sign)
  * [create-ecdh](#user-content-create-ecdh)
* Affected versions: >=3.4.0
* Package usage:
  * `node_modules/crypto-browserify`

### elliptic <a href="#user-content-elliptic" id="elliptic">#</a>
* Valid ECDSA signatures erroneously rejected in Elliptic
* Severity: **low**
* Reference: [https://github.com/advisories/GHSA-fc9h-whq2-v747](https://github.com/advisories/GHSA-fc9h-whq2-v747)
* Affected versions: *
* Package usage:
  * `node_modules/elliptic`

### node-gettext <a href="#user-content-node-gettext" id="node-gettext">#</a>
* node-gettext vulnerable to Prototype Pollution
* Severity: **moderate** (CVSS 5.9)
* Reference: [https://github.com/advisories/GHSA-g974-hxvm-x689](https://github.com/advisories/GHSA-g974-hxvm-x689)
* Affected versions: *
* Package usage:
  * `node_modules/node-gettext`

### node-stdlib-browser <a href="#user-content-node-stdlib-browser" id="node-stdlib-browser">#</a>
* Caused by vulnerable dependency:
  * [crypto-browserify](#user-content-crypto-browserify)
* Affected versions: *
* Package usage:
  * `node_modules/node-stdlib-browser`

### vite-plugin-node-polyfills <a href="#user-content-vite-plugin-node-polyfills" id="vite-plugin-node-polyfills">#</a>
* Caused by vulnerable dependency:
  * [node-stdlib-browser](#user-content-node-stdlib-browser)
* Affected versions: >=0.3.0
* Package usage:
  * `node_modules/vite-plugin-node-polyfills`

### vue-tsc <a href="#user-content-vue-tsc" id="vue-tsc">#</a>
* Caused by vulnerable dependency:
  * [@vue/language-core](#user-content-\@vue\/language-core)
* Affected versions: 1.7.0-alpha.0 - 2.0.28
* Package usage:
  * `node_modules/vue-tsc`