### PR TITLE
Fix nginx config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ location /whiteboard/ {
 	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	proxy_set_header Host $host;
 	
-	proxy_pass http://localhost:3002;
+	proxy_pass http://localhost:3002/;
 	
 	proxy_http_version 1.1;
 	proxy_set_header Upgrade $http_upgrade;


### PR DESCRIPTION
Due to how proxy_pass works in nginx, we need a slash at the end, otherwise, nginx will send the request as "/whiteboard/signal.io", which is not what the whiteboard server expects.

This is probably the reason for #193 