### PR TITLE
add excalidraw type to whiteboard file

### DIFF
--- a/websocket_server/ApiService.js
+++ b/websocket_server/ApiService.js
@@ -59,7 +59,7 @@ export default class ApiService {
 		console.log(`[${roomID}] Saving room data to server: ${roomData.length} elements, ${Object.keys(files).length} files`)
 
 		const url = `${this.NEXTCLOUD_URL}/index.php/apps/whiteboard/${roomID}`
-		const body = { data: { elements: roomData, files: this.cleanupFiles(roomData, files) } }
+		const body = { data: { type: 'excalidraw', elements: roomData, files: this.cleanupFiles(roomData, files) } }
 		const options = this.fetchOptions('PUT', null, body, roomID, lastEditedUser)
 		return this.fetchData(url, options)
 	}


### PR DESCRIPTION
In order to make excalidraw.com recognize files downloaded from whiteboard we need to tell it the type of file. If we add type excalidraw, users will be added to upload their files downloaded from nextcloud on other excalidraw implementations.