### PR TITLE
fix: prevent preview div from collapsing to 0px height

### DIFF
--- a/src/viewer.css
+++ b/src/viewer.css
@@ -10,7 +10,14 @@
 	top: 0;
 }
 
-.whiteboard-viewer__embedding {
-	min-height: min(200px, 50vh);
-	position: relative;
+.whiteboard-viewer__embedding .App {
+	min-height: max(400px, 50vh);
+
+	.excalidraw-wrapper {
+		position: absolute;
+		top: 0;
+		bottom: 0;
+		left: 0;
+		right: 0;
+	}
 }


### PR DESCRIPTION
The whiteboard preview in the text app editor is currently collapsing entirely, rendering it unusable. This issue has been observed in both Firefox and Chromium browsers. This commit addresses the problem by setting a minimum height of 400px for the preview, ensuring it remains visible and functional.

From:
![whiteboard-preview-current](https://github.com/user-attachments/assets/6c77955a-8955-4d62-aa63-32dffb6d7ecf)

To:
![whiteboard-preview-fixed](https://github.com/user-attachments/assets/b5748ea1-08d1-4c37-883a-7456dc4c66fc)

@nextcloud/designers: Are there any potential impacts this change might have on other parts of the application?