### PR TITLE
Adding restart policy and port declaration to README and compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The server requires the `NEXTCLOUD_URL` environment variable to be set to the UR
 The server can be run in a container using the following command:
 
 ```bash
-docker run -e JWT_SECRET_KEY=some-random -e NEXTCLOUD_URL=https://nextcloud.local --rm ghcr.io/nextcloud-releases/whiteboard:release
+docker run -p 3002:3002 -e JWT_SECRET_KEY=some-random -e NEXTCLOUD_URL=https://nextcloud.local --restart unless-stopped ghcr.io/nextcloud-releases/whiteboard:release
 ```
 
 Docker compose can also be used to run the server:
@@ -71,7 +71,7 @@ services:
     environment:
       - NEXTCLOUD_URL=https://nextcloud.local
       - JWT_SECRET_KEY=some-random-key
-      
+    restart: unless-stopped
 ```
 
 #### Building the image locally

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,3 +14,4 @@ services:
       - JWT_SECRET_KEY
       ## if you run this rootess, backup_dir needs to be in a place writeable to the non-root process, for example:
       - BACKUP_DIR=/tmp/backup
+    restart: unless-stopped


### PR DESCRIPTION
This PR adds the restart policy of unless-stopped to the README and docker-compose.yml and also adds the port declaration to the command. The added restart policy would restart the docker container unless the server admin stops the container by themself.

Adding this to the docker-compose.yml and the README is maybe more for convenience but would also prevent that deployments of the container would not automatically restart after e.g. an server update because an server admin forgot to add this to their deployment.