### PR TITLE
Add slash to Apache2 config (>=2.4.47)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ RewriteRule ^/?whiteboard/(.*) "ws://localhost:3002/$1" [P,L]
 #### Apache >= 2.4.47
 
 ```apache
-ProxyPass /whiteboard http://localhost:3002/ upgrade=websocket
+ProxyPass /whiteboard/ http://localhost:3002/ upgrade=websocket
 ```
 
 #### Nginx


### PR DESCRIPTION
Apache documentation says: "If the first argument ends with a trailing /, the second argument should also end with a trailing /, and vice versa. Otherwise, the resulting requests to the backend may miss some needed slashes and do not deliver the expected results."
(see 2nd warning on https://httpd.apache.org/docs/2.4/mod/mod_proxy.html#ProxyPass)

Actually for me, if I configure without the slash it will not work:
- Whiteboard shows "Failed to connect to the whiteboard server."
- Whiteboard settings shows "Failed to verify the connection: websocket error"