### PR TITLE
Add slash to Apache2 config (<2.4.47)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ docker build -t nextcloud-whiteboard-server -f Dockerfile .
 #### Apache < 2.4.47
 
 ```apache
-ProxyPass /whiteboard http://localhost:3002/
+ProxyPass /whiteboard/ http://localhost:3002/
 RewriteEngine on
 RewriteCond %{HTTP:Upgrade} websocket [NC]
 RewriteCond %{HTTP:Connection} upgrade [NC]


### PR DESCRIPTION
Apache documentation says: "If the first argument ends with a trailing /, the second argument should also end with a trailing /, and vice versa. Otherwise, the resulting requests to the backend may miss some needed slashes and do not deliver the expected results." (see 2nd warning on https://httpd.apache.org/docs/2.4/mod/mod_proxy.html#ProxyPass)

To be consistant a follow up to #484.

Actually for me, it runs smoothly both ways (Apache 2.4.58), maybe du to the dedicated RewriteRule.

