### PR TITLE
fix npm run watch

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "NODE_OPTIONS='--max-old-space-size=8192' vite --mode production build",
     "dev": "NODE_OPTIONS='--max-old-space-size=8192' vite --mode development build",
-    "watch": "vite --mode development build --watch",
+    "watch": "nodemon --watch src --ext js,jsx,ts,tsx,vue,scss,css --exec 'npm run dev'",
     "lint": "eslint --ext .js,.mjs,.ts,.tsx,.vue src websocket_server tests/integration ",
     "lint:fix": "eslint --ext .js,.mjs,.ts,.tsx,.vue src websocket_server tests/integration --fix",
     "stylelint": "stylelint 'src/**/*.{css,scss,sass}'",


### PR DESCRIPTION
use nodemon instead, vite 6.x with rollup 4.x prevents watch mode when input files are inside the output directory