### PR TITLE
ci: Run playwright on all stable versions

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -7,8 +7,15 @@ on:
 
 jobs:
   test:
+    strategy:
+      matrix:
+        server_version: [stable29, stable30, stable31, stable32, master]
+      fail-fast: false
     timeout-minutes: 60
     runs-on: ubuntu-latest
+    env:
+      SERVER_VERSION: ${{ matrix.server_version }}
+    name: Playwright Tests on Nextcloud ${{ matrix.server_version }}
     steps:
       - name: Checkout app
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -53,6 +60,6 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-report
+          name: playwright-report-${{ matrix.server_version }}
           path: playwright-report/
           retention-days: 30

--- a/playwright/start-nextcloud-server.mjs
+++ b/playwright/start-nextcloud-server.mjs
@@ -13,6 +13,11 @@ const start = async () => {
 }
 
 const getBranch = () => {
+	const serverVersion = process.env.SERVER_VERSION
+	if (serverVersion) {
+		return serverVersion
+	}
+
 	try {
 		const appinfo = readFileSync('appinfo/info.xml').toString()
 		const maxVersion = appinfo.match(
@@ -21,7 +26,7 @@ const getBranch = () => {
 		return maxVersion ? `stable${maxVersion}` : undefined
 	} catch (err) {
 		if (err.code === 'ENOENT') {
-			console.warn('No appinfo/info.xml found. Using default server banch.')
+			console.warn('No appinfo/info.xml found. Using default server branch.')
 		}
 	}
 }


### PR DESCRIPTION
Apparently we only ran e2e tests against the max-version, we should cover min as well, but for now running on all of them to see