### PR TITLE
Fix: add read-only EmbeddedViewer component for whiteboard nesting

### DIFF
--- a/playwright/e2e/embed.spec.ts
+++ b/playwright/e2e/embed.spec.ts
@@ -1,0 +1,41 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { expect } from '@playwright/test'
+import { test } from '../support/fixtures/random-user'
+
+test.beforeEach(async ({ page }) => {
+	await page.goto('apps/files')
+	await page.waitForURL(/apps\/files/)
+})
+
+test('embed whiteboard in another whiteboard', async ({ page }) => {
+	await page.getByRole('button', { name: 'New' }).click()
+	await page.getByRole('menuitem', { name: 'New whiteboard' }).click()
+	await page.keyboard.type('first whiteboard')
+	await page.getByRole('button', { name: 'Create' }).click()
+	await expect(page.getByText('Drawing canvas')).toBeVisible()
+
+	await page.goto('apps/files')
+	await page.waitForURL(/apps\/files/)
+
+	await page.getByRole('button', { name: 'New' }).click()
+	await page.getByRole('menuitem', { name: 'New whiteboard' }).click()
+	await page.getByRole('button', { name: 'Create' }).click()
+	await expect(page.getByText('Drawing canvas')).toBeVisible()
+
+	await page.getByTitle('Smart picker').click()
+	await expect(page.locator('.reference-picker')).toBeVisible({ timeout: 5000 })
+
+	await page.locator('#provider-select-input').click()
+	await page.keyboard.type('Files')
+	await page.keyboard.press('Enter')
+
+	await expect(page.locator('.file-picker')).toBeVisible({ timeout: 5000 })
+	await page.getByTitle('first whiteboard').click()
+	await page.getByLabel('Choose first whiteboard').click()
+
+	await expect(page.locator('.whiteboard-viewer__embedding').getByText('Drawing canvas')).toBeVisible()
+})

--- a/src/components/ReadOnlyViewer.tsx
+++ b/src/components/ReadOnlyViewer.tsx
@@ -70,7 +70,7 @@ const resolveVersionSource = (source: string) => {
 	}
 }
 
-export default function CompareViewer({
+export default function ReadOnlyViewer({
 	fileName,
 	versionSource,
 	fileVersion,
@@ -136,7 +136,7 @@ export default function CompareViewer({
 				if (abortController.signal.aborted) {
 					return
 				}
-				logger.error('[CompareViewer] Failed to load comparison scene', fetchError)
+				logger.error('[ReadOnlyViewer] Failed to load scene', fetchError)
 				setError(t('whiteboard', 'Could not load this version'))
 				setScene(null)
 			} finally {

--- a/src/utils/renderWhiteboardView.tsx
+++ b/src/utils/renderWhiteboardView.tsx
@@ -3,21 +3,21 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { StrictMode, Suspense, lazy, type ComponentType } from 'react'
+import { StrictMode, Suspense, lazy } from 'react'
 import { createRoot } from 'react-dom'
 
 import type { WhiteboardAppProps } from '../App'
 
 const App = lazy(() => import('../App'))
-const CompareViewer = lazy(() => import('../components/CompareViewer'))
+const ReadOnlyViewer = lazy(() => import('../components/ReadOnlyViewer'))
 
 type ViewerFileInfo = {
-	source?: string
-	fileVersion?: string | null
+    source?: string
+    fileVersion?: string | null
 }
 
 type ComparisonMatchContext = {
-	isViewerContext: boolean
+    isViewerContext: boolean
 }
 
 const normalizeVersionSource = (source: string | null): string | null => {
@@ -47,8 +47,8 @@ const matchesComparisonRequest = (versionSource: string | null, fileVersion: str
 	const compareVersion = compareInfo.fileVersion ?? null
 	if (
 		fileVersion
-		&& compareVersion
-		&& String(compareVersion) === String(fileVersion)
+        && compareVersion
+        && String(compareVersion) === String(fileVersion)
 	) {
 		return true
 	}
@@ -57,11 +57,11 @@ const matchesComparisonRequest = (versionSource: string | null, fileVersion: str
 }
 
 export type RenderWhiteboardViewOptions = WhiteboardAppProps & {
-	isComparisonView?: boolean
+    isComparisonView?: boolean
 }
 
 export type WhiteboardRootHandle = {
-	unmount: () => void
+    unmount: () => void
 }
 
 const shouldRenderComparison = (
@@ -80,6 +80,7 @@ const shouldRenderComparison = (
 export const renderWhiteboardView = (rootElement: HTMLElement, props: RenderWhiteboardViewOptions): WhiteboardRootHandle => {
 	const root = createRoot(rootElement)
 	const { isComparisonView, ...componentProps } = props
+
 	const comparisonMode = shouldRenderComparison(
 		{
 			isComparisonView,
@@ -89,7 +90,9 @@ export const renderWhiteboardView = (rootElement: HTMLElement, props: RenderWhit
 		{ isViewerContext: Boolean(rootElement.closest('.viewer__content')) },
 	)
 
-	const ComponentToRender = (comparisonMode ? CompareViewer : App) as ComponentType<WhiteboardAppProps>
+	const ComponentToRender = (componentProps.isEmbedded || comparisonMode)
+		? ReadOnlyViewer
+		: App
 
 	root.render(
 		<StrictMode>
@@ -105,11 +108,11 @@ export const renderWhiteboardView = (rootElement: HTMLElement, props: RenderWhit
 }
 
 declare global {
-	interface Window {
-		OCA?: {
-			Viewer?: {
-				compareFileInfo?: ViewerFileInfo
-			}
-		}
-	}
+    interface Window {
+        OCA?: {
+            Viewer?: {
+                compareFileInfo?: ViewerFileInfo
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Problem
When embedding a whiteboard inside another whiteboard using the Smart Picker, the embedded whiteboard would get stuck showing "Loading scene..." indefinitely and never render.

## Solution
Implemented a read-only `EmbeddedViewer` component for embedded whiteboards, following the same pattern as `CompareViewer`

Fixes #734