### PR TITLE
fix: prevent video embed errors from crashing whiteboard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -170,6 +170,24 @@ export default function App({
 		}
 	}, [excalidrawAPI])
 
+	useEffect(() => {
+		const handleVideoError = (e: Event) => {
+			const target = e.target as HTMLElement
+			if (target?.tagName === 'VIDEO') {
+				logger.error('[App] Caught video embed error:', e)
+				e.stopPropagation()
+				e.stopImmediatePropagation()
+				e.preventDefault()
+			}
+		}
+
+		window.addEventListener('error', handleVideoError, true)
+
+		return () => {
+			window.removeEventListener('error', handleVideoError, true)
+		}
+	}, [])
+
 	const recordingState = useRecording({ fileId: normalizedFileId })
 	const presentationState = usePresentation({ fileId: normalizedFileId })
 


### PR DESCRIPTION
There is an edge-case where videos with codec hevc/h.265 crash the whiteboard viewer in firefox on win11 only. This fix catches and logs the error, preventing the crash.