### PR TITLE
ci: Skip flaky playwright test for now

### DIFF
--- a/playwright/e2e/whiteboard-basic.spec.ts
+++ b/playwright/e2e/whiteboard-basic.spec.ts
@@ -19,7 +19,7 @@ test.beforeEach(async ({ page }) => {
 	await openFilesApp(page)
 })
 
-test('whiteboard content persists after reload and reopen', async ({ page }) => {
+test.skip('whiteboard content persists after reload and reopen', async ({ page }) => {
 	const boardName = `Persistent whiteboard ${Date.now()}`
 
 	await createWhiteboard(page, { name: boardName })


### PR DESCRIPTION
I've noticed this test seems flaky, skipping it for now. After merging I'll reopen a revert PR so we can investigate further