### PR TITLE
fix: Skip postinstall of redis-memory-server package

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,6 +119,9 @@
       }
     ]
   },
+  "redisMemoryServer": {
+    "disablePostinstall": "1"
+  },
   "engines": {
     "node": "^24.0.0",
     "npm": "^11.3.0"

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -4,12 +4,30 @@
  */
 
 import { defineConfig } from 'vitest/config'
+import { execSync } from 'child_process'
 
+process.env.REDISMS_DISABLE_POSTINSTALL = '0'
+
+let redisMemoryServerAvailable = false
+
+try {
+  console.log('Rebuilding redis-memory-server...')
+  execSync('npm rebuild redis-memory-server', { stdio: 'inherit' })
+  redisMemoryServerAvailable = true
+} catch (e) {
+  console.error('Failed to rebuild redis-memory-server:', e?.message ?? e)
+  console.warn('⚠️  Skipping Redis-dependent tests (multinode-redis.spec.mjs)')
+}
 export default defineConfig({
-  test: {
-    environment: 'node',
-    include: [
-      'tests/integration/*.spec.?(c|m)[jt]s?(x)'
-    ],
-  },
+	test: {
+		environment: 'node',
+		include: [
+			'tests/integration/*.spec.?(c|m)[jt]s?(x)',
+		],
+		exclude: redisMemoryServerAvailable
+			? []
+			: [
+				'**/multinode-redis.spec.mjs',
+			],
+	},
 })


### PR DESCRIPTION
Should fix build on daily as on alpine we do not have build dependencies for redis (and should not need them just for building the app)

For running the tests I added the installation to the vitest config to do that only when needed

Fix #870 