### PR TITLE
fix: use Viewer for public whiteboard shares on NC29

### DIFF
--- a/lib/Listener/BeforeTemplateRenderedListener.php
+++ b/lib/Listener/BeforeTemplateRenderedListener.php
@@ -39,6 +39,10 @@ class BeforeTemplateRenderedListener implements IEventListener {
 			return;
 		}
 
+		if ($event->getScope() === BeforeTemplateRenderedEvent::SCOPE_PUBLIC_SHARE_AUTH) {
+			return;
+		}
+
 		try {
 			$node = $event->getShare()->getNode();
 		} catch (NotFoundException) {

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -6,3 +6,4 @@
 @use './globals/layout';
 @use './overrides/excalidraw';
 @use './modes/viewer';
+@use './modes/public-share';

--- a/src/styles/modes/_public-share.scss
+++ b/src/styles/modes/_public-share.scss
@@ -1,0 +1,64 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#body-public.whiteboard-public-share {
+	--header-height: 0px;
+	--footer-height: 0px;
+	--whiteboard-public-share-main-text: var(--color-main-text);
+}
+
+#body-public.whiteboard-public-share #header {
+	display: none;
+}
+
+#body-public.whiteboard-public-share #content.app-files_sharing {
+	--body-container-margin: 0px;
+	--body-container-radius: 0px;
+	--footer-height: 0px;
+	--body-height: calc(100% - env(safe-area-inset-bottom));
+	margin: 0 !important;
+}
+
+#body-public.whiteboard-public-share #content.app-files_sharing + footer {
+	display: none;
+}
+
+#body-public.whiteboard-public-share #content.app-files_sharing #app-content {
+	overflow: hidden;
+}
+
+#body-public.whiteboard-public-share #content.app-files_sharing #files-public-content,
+#body-public.whiteboard-public-share #content.app-files_sharing #preview {
+	height: 100%;
+}
+
+#body-public.whiteboard-public-share #content.app-files_sharing #preview {
+	position: relative;
+}
+
+#body-public.whiteboard-public-share #content.app-files_sharing .whiteboard {
+	height: 100%;
+	width: 100%;
+	inset: 0;
+}
+
+#body-public.whiteboard-public-share .network-status,
+#body-public.whiteboard-public-share .grid-toggle-button {
+	display: none;
+}
+
+#body-public.whiteboard-public-share .excalidraw .sidebar-trigger__label {
+	line-height: 1.2;
+	height: auto;
+}
+
+#body-public.whiteboard-public-share #viewer .modal-header .button-vue {
+	color: var(--whiteboard-public-share-main-text) !important;
+}
+
+#body-public.whiteboard-public-share #viewer .whiteboard {
+	top: 50px;
+	height: calc(100% - 50px);
+}


### PR DESCRIPTION
## Summary
Public share links to whiteboard files on Nextcloud 29 render inside the legacy `files_sharing` public preview container (`#preview`/`#imgframe`), which has its own header/footer and constrained layout. This causes the whiteboard to look boxed and misaligned compared to NC32+.
This change opens public whiteboard shares via the Nextcloud Viewer modal for a consistent fullscreen experience.
## Root Cause
On NC29, the whiteboard embeds inside `#imgframe` which has constrained dimensions (`height: 75%`, `width: 80%`, `padding: 32px`). NC32+ rewrote `files_sharing` to automatically trigger Viewer for file shares, but NC29's `public.js` only auto-opens Viewer for image/video/audio - not custom MIME types like whiteboard.
A CSS-only fix doesn't work because hiding the header breaks the `height: 100%` cascade throughout the legacy template structure.
## Solution
- Register the whiteboard Viewer handler on public share pages
- Call `viewerApi.openWith('whiteboard', ...)` to open in a fullscreen Viewer modal
- Fallback to embedded rendering if Viewer is unavailable
- Add scoped CSS to hide header/footer and adjust Viewer styling
- Skip script injection on password prompt pages
## Scope
- Only affects public shares of whiteboard files
- Non-whiteboard public shares and authenticated Viewer behavior unchanged