### PR TITLE
feat: add link to search tab in main menu

### DIFF
--- a/src/components/ExcalidrawMenu.tsx
+++ b/src/components/ExcalidrawMenu.tsx
@@ -198,7 +198,8 @@ export const ExcalidrawMenu = memo(function ExcalidrawMenu({ fileNameWithoutExte
 			</MainMenu.Item>
 			<MainMenu.Item
 				icon={<Icon path={mdiMagnify} size={0.75} />}
-				onSelect={openLibrarySearch}>
+				onSelect={openLibrarySearch}
+				shortcut={isMacPlatform ? '⌘+F' : 'Ctrl+F'}>
 				{t('whiteboard', 'Find text on canvas')}
 			</MainMenu.Item>
 			<RecordingMenuItem


### PR DESCRIPTION
## Add "Find text on canvas" menu item

Adds a new menu item to the main hamburger menu that opens the library search functionality.

### Changes
- Added "Find text on canvas" menu item with magnifying glass icon
- Clicking the item triggers Ctrl+F (Cmd+F on Mac), which opens the library sidebar with the search tab active

### Implementation
The feature uses Excalidraw's built-in keyboard shortcut (Ctrl/Cmd+F) by dispatching a native keyboard event, ensuring consistent behavior with the existing search functionality.

<img width="316" height="525" alt="Screenshot from 2025-12-17 15-12-06" src="https://github.com/user-attachments/assets/3cfc2912-d7d6-4e4a-94c4-e4f5cf7e98ee" />

<img width="305" height="284" alt="Screenshot from 2025-12-17 15-12-22" src="https://github.com/user-attachments/assets/fa689ecc-48de-41cc-a89c-5d60bfbdd68b" />
