### PR TITLE
fix: prevent wheel events in embeds propagating to parent

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -213,6 +213,30 @@ export default function App({
 	})
 
 	useEffect(() => {
+		if (!excalidrawAPI) return
+
+		const preventEmbedWheelPropagation = () => {
+			document.querySelectorAll('.excalidraw__embeddable-container').forEach(container => {
+				if (!container.dataset.wheelPrevented) {
+					container.addEventListener('wheel', (e) => e.stopPropagation())
+					container.dataset.wheelPrevented = 'true'
+				}
+			})
+		}
+
+		preventEmbedWheelPropagation()
+
+		const observer = new MutationObserver(preventEmbedWheelPropagation)
+		const wrapper = document.querySelector('.excalidraw')
+
+		if (wrapper) {
+			observer.observe(wrapper, { childList: true })
+		}
+
+		return () => observer.disconnect()
+	}, [excalidrawAPI])
+
+	useEffect(() => {
 		const onRestoreRequested = (payload: any) => {
 			const payloadFileId = Number(payload?.fileInfo?.id)
 			const mimetype = payload?.fileInfo?.mimetype


### PR DESCRIPTION
## Problem
When scrolling or zooming inside an embedded element, the wheel events would propagate to the parent, causing both the embed and the parent to zoom/pan simultaneously.

## Solution
Attached wheel event listeners to each embed container that call `stopPropagation()` to prevent events propagating to the parent.