### PR TITLE
fix: linked files added via smartpicker open in new tab

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -371,6 +371,7 @@ export default function App({
 
 		if (isInternalLink && !isNewTab && !isNewWindow) {
 			event.preventDefault()
+			window.open(link, '_blank')
 		}
 	}, [])
 


### PR DESCRIPTION
Inserting a file (e.g. a markdown file) using the smart picker also adds a link to that file. The link is placed right above the embedded file in the whiteboard.

Before: Clicking on the link did not trigger any action.

Now: Clicking on the link opens a new tab containing the linked file.

<img width="556" height="379" alt="Screenshot from 2025-12-22 12-07-05" src="https://github.com/user-attachments/assets/89728acf-9aab-4fc6-997d-b4f4d64ed9d7" />
