### PR TITLE
Fix embed and follow e2e regressions

### DIFF
--- a/src/components/VueWrapper.tsx
+++ b/src/components/VueWrapper.tsx
@@ -60,23 +60,31 @@ const VueWrapper = function(
 		visibleWarning = t('whiteboard', 'Please share the board with users; otherwise, they will not be able to see it.')
 	}
 
+	const embedContentStyle = {
+		minHeight: 'max(400px, 50vh)',
+		height: '100%',
+		width: '100%',
+	}
+
 	if (!linkToOpenSharingDetails) {
-		return <div id="vue-component" ref={vueRef}></div>
+		return <div id="vue-component" ref={vueRef} className="whiteboard-embed__content" style={embedContentStyle}></div>
 	}
 
 	return (
-		<div>
-			<div style={{
-				padding: '0.5rem',
-				fontStyle: 'italic',
-				color: '#666',
-			}}>
+		<div className="whiteboard-embed__wrapper">
+			<div
+				className="whiteboard-embed__notice"
+				style={{
+					padding: '0.5rem',
+					fontStyle: 'italic',
+					color: '#666',
+				}}>
 				{visibleWarning}
 				<a href={linkToOpenSharingDetails} target={'_blank'} style={{ marginLeft: '0.5rem' }}>
 					<Icon path={mdiAccountPlusOutline} size={1} style={{ marginBottom: '-4px' }} />
 				</a>
 			</div>
-			<div id="vue-component" ref={vueRef}></div>
+			<div id="vue-component" ref={vueRef} className="whiteboard-embed__content" style={embedContentStyle}></div>
 		</div>
 	)
 }

--- a/src/stores/useCollaborationStore.ts
+++ b/src/stores/useCollaborationStore.ts
@@ -148,3 +148,25 @@ export const useCollaborationStore = create<CollaborationStore>()((set) => ({
 
 	setVotings: (votings) => set({ votings }),
 }))
+
+type WhiteboardTestHooks = {
+	collaborationStore?: typeof useCollaborationStore
+}
+
+declare global {
+	interface Window {
+		__whiteboardTest?: boolean
+		__whiteboardTestHooks?: WhiteboardTestHooks & Record<string, unknown>
+	}
+}
+
+const attachTestHooks = () => {
+	if (typeof window === 'undefined' || !window.__whiteboardTest) {
+		return
+	}
+
+	window.__whiteboardTestHooks = window.__whiteboardTestHooks || {}
+	window.__whiteboardTestHooks.collaborationStore = useCollaborationStore
+}
+
+attachTestHooks()

--- a/src/styles/modes/_viewer.scss
+++ b/src/styles/modes/_viewer.scss
@@ -10,6 +10,25 @@
 	top: 0;
 }
 
+.whiteboard.whiteboard-viewer__embedding {
+	position: relative;
+	height: 100%;
+	min-height: max(400px, 50vh);
+}
+
+.whiteboard-embed__wrapper {
+	display: flex;
+	flex-direction: column;
+	min-height: 100%;
+	height: 100%;
+}
+
+.whiteboard-embed__content {
+	flex: 1;
+	height: 100%;
+	min-height: max(400px, 50vh);
+}
+
 .whiteboard-viewer__embedding .App {
 	min-height: max(400px, 50vh);
 


### PR DESCRIPTION
## Why
Root cause: e2e timing + layout. Not product regression; flakes from embed container height + collab readiness.
- embed.spec.ts: embeddable root had 0/auto height in viewer => canvas never visible. Fix: enforce wrapper/content height + min-height. Files: src/components/VueWrapper.tsx, src/styles/modes/_viewer.scss.
- follow.spec.ts: file_id read before whiteboard InitialState ready + websocket not joined. NC29/30 load InitialState later than NC31/32, so only older cores failed. Fix: add test hook, wait socket connected/in-room, request viewport via socket. Files: src/stores/useCollaborationStore.ts, playwright/e2e/follow.spec.ts.

No critical behavior change. Stabilized flakies by:
- deterministic sizing for embed viewer
- deterministic readiness for collab follow
