### PR TITLE
fix: handle br tags for markdown and svg table conversion

### DIFF
--- a/src/components/TableEditorDialog.vue
+++ b/src/components/TableEditorDialog.vue
@@ -197,11 +197,20 @@ export default defineComponent({
 
 				let markdown = ''
 
+				// helper function to get cell content while preserving line breaks
+				const getCellContent = (cell) => {
+					const clone = cell.cloneNode(true)
+					const brs = clone.querySelectorAll('br')
+					brs.forEach(br => {
+						br.replaceWith(document.createTextNode('<br>'))
+					})
+					return clone.textContent.trim().replace(/\|/g, '\\|')
+				}
+
 				// Process first row as header
 				const firstRow = rows[0]
 				const headerCells = Array.from(firstRow.querySelectorAll('th, td'))
-				// Escape pipe characters in cell content for markdown
-				const headers = headerCells.map(cell => cell.textContent.trim().replace(/\|/g, '\\|'))
+				const headers = headerCells.map(cell => getCellContent(cell))
 				markdown += '| ' + headers.join(' | ') + ' |\n'
 
 				// Add separator
@@ -210,8 +219,7 @@ export default defineComponent({
 				// Process remaining rows as body
 				for (let i = 1; i < rows.length; i++) {
 					const cells = Array.from(rows[i].querySelectorAll('td, th'))
-					// Escape pipe characters in cell content for markdown
-					const values = cells.map(cell => cell.textContent.trim().replace(/\|/g, '\\|'))
+					const values = cells.map(cell => getCellContent(cell))
 					markdown += '| ' + values.join(' | ') + ' |\n'
 				}
 

--- a/src/utils/tableToImage.ts
+++ b/src/utils/tableToImage.ts
@@ -141,7 +141,8 @@ function createSvgDataUrl(element: HTMLElement): string {
 	const height = Math.ceil(bbox.height) + (padding * 2)
 
 	// Get the table HTML with all our style overrides applied
-	const tableHtml = table.outerHTML
+	let tableHtml = table.outerHTML
+	tableHtml = tableHtml.replace(/<br>/g, '<br />')
 
 	const svg = `
 		<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}">


### PR DESCRIPTION
-  Converts `<br>` tags to xhtml-compliant `<br />` to fix SVG rendering of tables with line breaks.
-  Preserve line breaks when converting html to markdown so they persist when editing tables.

Requires: https://github.com/nextcloud/text/pull/8169