### PR TITLE
fix: hide table settings button

### DIFF
--- a/src/components/TableEditorDialog.vue
+++ b/src/components/TableEditorDialog.vue
@@ -265,7 +265,8 @@ export default defineComponent({
 	// These aren't needed in table-only editing mode
 	:deep(.floating-buttons),
 	:deep(.drag-handle),
-	:deep(.drag-button) {
+	:deep(.drag-button),
+	:deep(.table-settings) {
 		display: none !important;
 	}
 }


### PR DESCRIPTION
The table settings menu (with delete table option) is not needed in the whiteboards plain table editor dialog.