### PR TITLE
feat: increase table editing modal width

### DIFF
--- a/src/components/TableEditorDialog.vue
+++ b/src/components/TableEditorDialog.vue
@@ -256,7 +256,7 @@ export default defineComponent({
 <template>
 	<NcModal v-if="show"
 		:can-close="true"
-		size="large"
+		class="table-editor-modal"
 		@close="onCancel">
 		<div class="table-editor-dialog">
 			<div class="editor-header">
@@ -290,6 +290,11 @@ export default defineComponent({
 </template>
 
 <style scoped lang="scss">
+.table-editor-modal :deep(.modal-container) {
+	max-width: 90vw !important;
+	width: 90vw !important;
+}
+
 .table-editor-dialog {
 	display: flex;
 	flex-direction: column;


### PR DESCRIPTION
Before:
<img width="1824" height="1008" alt="Screenshot from 2026-01-20 12-11-55" src="https://github.com/user-attachments/assets/6dc4afad-3bc1-4a8c-a420-163a22d91393" />

After:
<img width="1908" height="952" alt="Screenshot from 2026-01-20 11-52-21" src="https://github.com/user-attachments/assets/a2487de8-e42a-428f-a5ff-a6c59b03cc2b" />
