### PR TITLE
fix: preserve table width on editing content

### DIFF
--- a/src/hooks/useTableInsertion.tsx
+++ b/src/hooks/useTableInsertion.tsx
@@ -115,6 +115,8 @@ export function useTableInsertion() {
 					x: tableElement.x,
 					y: tableElement.y,
 					angle: tableElement.angle,
+					width: tableElement.width,
+					height: (tableElement.width / newImageElement.width) * newImageElement.height,
 
 					// Increment version numbers to ensure this update wins during collaborative reconciliation
 					// Excalidraw uses these to resolve conflicts when multiple users edit simultaneously


### PR DESCRIPTION
Fixes table dimensions resetting to default when editing table content.
This fix preserves the tables width and scales height proportionally to maintain aspect ratio.