### PR TITLE
fix: reset active tool when clicking custom toolbar button

### DIFF
--- a/src/components/EmojiPickerButton.vue
+++ b/src/components/EmojiPickerButton.vue
@@ -19,6 +19,9 @@ export default defineComponent({
 		}
 	},
 	methods: {
+		handleClick() {
+			this.$emit('open')
+		},
 		onSelectEmoji(emoji) {
 			this.$emit('selected', emoji)
 		},
@@ -32,7 +35,7 @@ export default defineComponent({
 	<NcEmojiPicker :aria-label="t('whiteboard', 'Add reaction')"
 		:title="t('whiteboard', 'Add reaction')"
 		@select-data="onSelectEmoji">
-		<button class="dropdown-menu-button">
+		<button class="dropdown-menu-button" @click="handleClick">
 			<svg viewBox="0 0 24 24" role="presentation" style="width: 1.5rem; height: 1.5rem;">
 				<path :d="mdiStickerEmoji" style="fill: currentcolor" />
 			</svg>

--- a/src/components/ToolbarButton.tsx
+++ b/src/components/ToolbarButton.tsx
@@ -5,6 +5,8 @@
 
 import { createRoot, type Root } from 'react-dom/client'
 import { Icon } from '@mdi/react'
+import { useExcalidrawStore } from '../stores/useExcalidrawStore'
+import type { ExcalidrawImperativeAPI } from '@nextcloud/excalidraw/dist/types/excalidraw/types'
 
 interface ToolbarButtonConfig {
 	class: string
@@ -13,6 +15,13 @@ interface ToolbarButtonConfig {
 	label?: string
 	onClick?: () => void
 	customContainer?: (container: HTMLElement) => void
+}
+
+export function resetActiveTool() {
+	const excalidrawApi = useExcalidrawStore.getState().excalidrawAPI as ExcalidrawImperativeAPI | null
+	if (excalidrawApi) {
+		excalidrawApi.setActiveTool({ type: 'selection' })
+	}
 }
 
 export function renderToolbarButton(config: ToolbarButtonConfig): Root | null {
@@ -34,12 +43,17 @@ export function renderToolbarButton(config: ToolbarButtonConfig): Root | null {
 		return null
 	}
 
+	const handleClick = () => {
+		resetActiveTool()
+		config.onClick?.()
+	}
+
 	const root = createRoot(container)
 	root.render(
 		<button
 			className={`dropdown-menu-button ${config.buttonClass || ''}`}
 			aria-label={config.label}
-			onClick={config.onClick}
+			onClick={handleClick}
 			title={config.label}>
 			<Icon path={config.icon} size={1} />
 		</button>,

--- a/src/hooks/useEmojiPicker.tsx
+++ b/src/hooks/useEmojiPicker.tsx
@@ -15,7 +15,7 @@ import Vue from 'vue'
 import { Notomoji } from '@svgmoji/noto'
 import EmojiData from 'svgmoji/emoji.json'
 import { imagePath } from '@nextcloud/router'
-import { renderToolbarButton } from '../components/ToolbarButton'
+import { renderToolbarButton, resetActiveTool } from '../components/ToolbarButton'
 
 type EmojiObj = {
 	native: string
@@ -132,6 +132,7 @@ export function useEmojiPicker() {
 				container.appendChild(div)
 				const View = Vue.extend(EmojiPickerButton)
 				const vueComponent = new View({}).$mount(div)
+				vueComponent.$on('open', () => resetActiveTool())
 				vueComponent.$on('selected', (emoji: string) => {
 					loadToExcalidraw(emoji)
 				})


### PR DESCRIPTION
When a drawing tool is active and a custom toolbar button is clicked, the drawing tool remains active causing unwanted behavior on canvas interactions.

Custom toolbar buttons perform one-time actions and should reset to the default selection tool rather than keeping drawing tools active.