### PR TITLE
fix: Proper placeholders for presenter strings in javascript

### DIFF
--- a/src/components/Presentation.tsx
+++ b/src/components/Presentation.tsx
@@ -187,9 +187,9 @@ export const PresentationMenuItem = memo(function PresentationMenuItem({
 		tooltip = t('whiteboard', 'Starting presentation….')
 	} else if (isPresentationMode && presenterName) {
 		icon = mdiPresentation
-		text = t('whiteboard', '%s is presenting', [presenterName])
+		text = t('whiteboard', '{presenterName} is presenting', { presenterName })
 		className += ' presentation-button--watching'
-		tooltip = t('whiteboard', '%s is currently presenting. Others will follow their viewport.', [presenterName])
+		tooltip = t('whiteboard', '{presenterName} is currently presenting. Others will follow their viewport.', { presenterName })
 	} else if (!isConnected) {
 		className += ' presentation-button--disconnected'
 		text = t('whiteboard', 'Start Presentation (Offline)')


### PR DESCRIPTION
Javascript only supports named placeholders according to https://docs.nextcloud.com/server/stable/developer_manual/basics/translations.html#javascript-typescript-vue