### PR TITLE
chore: Bump max-version to 33

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -40,7 +40,7 @@ The official whiteboard app for Nextcloud. It allows users to create and share w
 	<screenshot>https://raw.githubusercontent.com/nextcloud/whiteboard/main/screenshots/screenshot1.png</screenshot>
 
 	<dependencies>
-		<nextcloud min-version="28" max-version="32"/>
+		<nextcloud min-version="28" max-version="33"/>
 	</dependencies>
 
 	<settings>


### PR DESCRIPTION
1.5.4-rc.1 had the 33 compatibility https://github.com/nextcloud/whiteboard/commit/27617981dc15b24787c3e443f56d45bf7b4bd000 but was released from stable1.5 branch while 1.5.4 itself was released from main. We should bump main as well as we discussed yesterday to rather release from main