### PR TITLE
fix: enable zen mode shortcut

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -90,7 +90,6 @@ export default function App({
 
 	const {
 		setConfig,
-		zenModeEnabled,
 		gridModeEnabled,
 		initialDataPromise,
 		resetInitialDataPromise,
@@ -98,7 +97,6 @@ export default function App({
 		setGridModeEnabled,
 	} = useWhiteboardConfigStore(useShallow(state => ({
 		setConfig: state.setConfig,
-		zenModeEnabled: state.zenModeEnabled,
 		gridModeEnabled: state.gridModeEnabled,
 		initialDataPromise: state.initialDataPromise,
 		resetInitialDataPromise: state.resetInitialDataPromise,
@@ -501,7 +499,6 @@ export default function App({
 					onPointerUpdate={onPointerUpdate}
 					onChange={handleOnChange}
 					viewModeEnabled={isReadOnly}
-					zenModeEnabled={zenModeEnabled}
 					gridModeEnabled={gridModeEnabled}
 					theme={theme}
 					name={fileNameWithoutExtension}


### PR DESCRIPTION
## Summary
- stop forcing zenModeEnabled so Excalidraw can toggle via shortcut

## Related
- depends on nextcloud-deps/excalidraw#13 (shortcut/help fixes) for full story
