### PR TITLE
fix: include existing elements when adding voting to canvas

### DIFF
--- a/src/components/VotingSidebar.tsx
+++ b/src/components/VotingSidebar.tsx
@@ -241,7 +241,7 @@ export function VotingSidebar({ votings, onVote, onEndVoting, onStartVoting, exc
 			}
 
 			excalidrawAPI.updateScene({
-				elements: [...elements],
+				elements: [...existingElements, ...elements],
 			})
 		} catch (error) {
 			console.error('Error adding voting results to canvas:', error)


### PR DESCRIPTION
When inserting a voting to canvas, the existing elements disappeared and were replaced with the voting elements. This fix includes  them when inserting a voting.