### PR TITLE
fix: adjust zindex so comments don't overlap controls

### DIFF
--- a/src/components/CommentPopover.scss
+++ b/src/components/CommentPopover.scss
@@ -5,7 +5,7 @@
 
 .comment-popover {
   position: absolute;
-  z-index: 1000;
+  z-index: 3;
   pointer-events: auto;
   transform: translate(0.5rem, -100%);
   margin-top: -1.25rem;

--- a/src/hooks/useComment.scss
+++ b/src/hooks/useComment.scss
@@ -7,7 +7,7 @@
   position: absolute;
   inset: 0;
   pointer-events: none;
-  z-index: 4;
+  z-index: 3;
 }
 
 .comment-pin {


### PR DESCRIPTION
Fixes https://github.com/nextcloud/whiteboard/issues/859