### PR TITLE
fix: generate file id when validating image uploads

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -434,8 +434,9 @@ export default function App({
 			const maxSizeMb = maxImageSizeMb ?? 0
 			throw new Error(t('whiteboard', 'Max image size is {max} MB', { max: maxSizeMb }))
 		}
-		// Return empty string so Excalidraw falls back to its default ID generator.
-		return ''
+
+		// must return an id, excalidraws id generator only runs when the callback prop is not set
+		return Array.from({ length: 40 }, () => Math.floor(Math.random() * 16).toString(16)).join('')
 	}, [maxImageSizeBytes, maxImageSizeMb])
 
 	const handleOnChange = useCallback(() => {


### PR DESCRIPTION
### Summary
Fixes image upload by generating file id in the `generateIdForFile` callback.

### Problem
Excalidraw checks `prop.generateIdFromFile as Promise || generateIdFromFile()`. Since Promise objects are always truthy the || operator never evaluates the fallback if the prop is set. If the callback prop is provided, a valid id must be returned.

### Future improvement:
Add a callback prop to the excalidraw library to handle file validation (like size checks) separately from id generation, avoiding the wrong responsibility of mixing size checks with id generation.

Resolves [1034](https://github.com/nextcloud/whiteboard/issues/1034)