### PR TITLE
fix: improve recording stability

### DIFF
--- a/src/hooks/useFollowedUser.ts
+++ b/src/hooks/useFollowedUser.ts
@@ -93,8 +93,17 @@ export function useFollowedUser({ excalidrawAPI, fileId }: UseFollowedUserOption
 				status: state.status,
 			})
 		}
+
+		const unsubscribe = useCollaborationStore.subscribe((state) => {
+			if (state.socket?.connected) {
+				window.collaborationReady = true
+				unsubscribe()
+			}
+		})
+
 		return () => {
 			delete window.followUser
+			delete window.collaborationReady
 		}
 	}, [excalidrawAPI, fileId])
 }

--- a/websocket_server/Services/RecordingControlService.js
+++ b/websocket_server/Services/RecordingControlService.js
@@ -57,7 +57,6 @@ export default class RecordingControlService {
 		const { fileId, recordingUrl, uploadToken, autoUploadOnDisconnect = false } = data
 		const roomID = fileId.toString()
 		const sessionKey = `${roomID}_${socket.id}`
-		const startedAt = Date.now()
 
 		try {
 			if (!socket.rooms.has(roomID)) {
@@ -91,6 +90,7 @@ export default class RecordingControlService {
 
 			console.log(`[${sessionKey}] Starting recording`)
 			await recorder.startRecording(roomID, socketData.user.id)
+			const startedAt = Date.now()
 
 			const username = socketData.user.displayName || socketData.user.name || 'Unknown User'
 			this.recordingServices.set(recordingKey, {


### PR DESCRIPTION
- Fix recording failing when crossing a minute boundary, output path is now stored at start and reused on stop instead of being recomputed
- Fix page.screencast() not being awaited, causing stop to fail if called shortly after start
- Fix duration timer showing inflated values by capturing startedAt after init completes instead of before
- Fix viewport following being called before socket is connected, replaced blind 2s timeout with window.collaborationReady flag set when socket connects
- Remux recording with ffmpeg after stop to add missing duration and index metadata as puppeteer screencast does not include them
- Wait for screencast file to fully flush to disk before processing with ffmpeg
- Remove some debug/test code from `initializeUserTracking`