### PR TITLE
fix: hide loading message from recording

### DIFF
--- a/websocket_server/Services/RecordingService.js
+++ b/websocket_server/Services/RecordingService.js
@@ -339,7 +339,7 @@ export default class RecordingService extends EventEmitter {
 			const formattedDate = new Date().toISOString().slice(0, 16).replace('T', ' ').replace(':', '-')
 			const outputPath = path.join(sessionPath, `${formattedDate}.webm`)
 
-			await page.addStyleTag({ content: '.recording-overlay { display: none !important; }' })
+			await page.addStyleTag({ content: '.recording-overlay { display: none !important; } .LoadingMessage { display: none !important; }' })
 
 			// Start browser-based recording
 			page.screencast({ path: outputPath, ffmpegPath: '/usr/bin/ffmpeg' }).then(mediaRecorder => {


### PR DESCRIPTION
Hide loading messages in whiteboard recordings as they are not relevant in the headless recording context and sometimes got stuck even when the recording was working fine.