### PR TITLE
incremental collaboration sync with targeted bootstrap

### DIFF
--- a/src/hooks/useCollaboration.ts
+++ b/src/hooks/useCollaboration.ts
@@ -31,6 +31,7 @@ import type { ClientToServerEvents, CollaborationSocket, ServerToClientEvents } 
 
 enum BroadcastType {
 	SceneInit = 'SCENE_INIT', // Incoming scene data from others
+	SceneUpdate = 'SCENE_UPDATE', // Incoming incremental scene data from others
 	SceneRestore = 'SCENE_RESTORE', // Force replace scene from authoritative source
 	MouseLocation = 'MOUSE_LOCATION', // Incoming cursor data
 	ImageAdd = 'IMAGE_ADD', // Incoming image data from others
@@ -591,16 +592,22 @@ export function useCollaboration() {
 					break
 				}
 				case BroadcastType.SceneInit:
+				case BroadcastType.SceneUpdate:
 					if (Array.isArray(decoded.payload?.elements)) {
+						console.log('[Collaboration] Received scene payload', {
+							type: decoded.type,
+							elementCount: decoded.payload.elements.length,
+							sampleElementIds: decoded.payload.elements.slice(0, 10).map((element: ExcalidrawElement) => element.id),
+						})
 						const elementsString = JSON.stringify(decoded.payload.elements)
 						if (elementsString === lastElementsString) {
-							console.warn('[Collaboration] Received identical SceneInit payload, skipping update')
+							console.warn('[Collaboration] Received identical scene payload, skipping update')
 							break
 						}
 						queueSceneUpdate(decoded.payload.elements)
 						lastElementsString = JSON.stringify(decoded.payload.elements)
 					} else {
-						console.warn('[Collaboration] Invalid SceneInit payload:', decoded.payload)
+						console.warn('[Collaboration] Invalid scene payload:', decoded.payload)
 					}
 					break
 				case BroadcastType.MouseLocation:
@@ -662,17 +669,32 @@ export function useCollaboration() {
 		setDedicatedSyncer(data.isSyncer)
 	}, [setDedicatedSyncer])
 
-	// Handle user joined event - broadcast all images if we're the syncer
+	// Handle user joined event - broadcast the current full scene and images if we're the syncer
 	const handleUserJoined = useCallback((data: { userId: string, userName: string, socketId: string, isSyncer: boolean }) => {
-		// If we are the syncer, broadcast all our images to the new user
+		// If we are the syncer, re-broadcast the current full scene so late joiners
+		// reconcile against the latest peer state via Excalidraw's built-in merge.
 		const { isDedicatedSyncer } = useCollaborationStore.getState()
 		if (isDedicatedSyncer && excalidrawAPI) {
-			console.log(`[Collaboration] Broadcasting images to new user: ${data.userName}`)
+			console.log(`[Collaboration] Broadcasting full scene to new user: ${data.userName}`)
 
+			const elements = excalidrawAPI.getSceneElementsIncludingDeleted()
 			const files = excalidrawAPI.getFiles()
 			const socket = useCollaborationStore.getState().socket
 
 			if (!socket || !socket.connected || !fileId) return
+
+			const sceneData = { type: BroadcastType.SceneInit, payload: { elements } }
+			const sceneJson = JSON.stringify(sceneData)
+			const sceneBuffer = new TextEncoder().encode(sceneJson)
+			socket.emit('server-broadcast', `${fileId}`, sceneBuffer, [])
+
+			console.log('[Collaboration] Re-broadcasted full scene for room convergence', {
+				targetUser: data.userName,
+				elementsCount: elements.length,
+				sampleElementIds: elements.slice(0, 10).map((element) => element.id),
+			})
+
+			console.log(`[Collaboration] Broadcasting images to new user: ${data.userName}`)
 
 			// Broadcast each image file
 			Object.entries(files).forEach(([, file]) => {

--- a/src/hooks/useSync.ts
+++ b/src/hooks/useSync.ts
@@ -18,9 +18,17 @@ import type { ExcalidrawElement } from '@excalidraw/excalidraw/types/element/typ
 import type { BinaryFiles } from '@excalidraw/excalidraw/types/types'
 import type { CollaborationSocket } from '../types/collaboration'
 import type { WorkerInboundMessage } from '../types/protocol'
+import {
+	buildBroadcastedElementVersions,
+	computeElementVersionHash,
+	getIncrementalSceneElements,
+	updateBroadcastedElementVersions,
+} from '../utils/syncSceneData'
+import type { BroadcastedElementVersions } from '../utils/syncSceneData'
 
 enum SyncMessageType {
 	SceneInit = 'SCENE_INIT',
+	SceneUpdate = 'SCENE_UPDATE',
 	ImageAdd = 'IMAGE_ADD',
 	MouseLocation = 'MOUSE_LOCATION',
 	ViewportUpdate = 'VIEWPORT_UPDATE',
@@ -28,9 +36,10 @@ enum SyncMessageType {
 	ServerVolatileBroadcast = 'server-volatile-broadcast',
 }
 
-const LOCAL_SYNC_DELAY = 1000
+const LOCAL_SYNC_DELAY = 200
 const SERVER_API_SYNC_DELAY = 10000
 const WEBSOCKET_SYNC_DELAY = 500
+const FULL_SCENE_HEALING_INTERVAL = 20000
 const CURSOR_SYNC_DELAY = 50
 
 export function useSync() {
@@ -67,11 +76,12 @@ export function useSync() {
 		})),
 	)
 
-	const { isDedicatedSyncer, status: collabStatus, socket } = useCollaborationStore(
+	const { isDedicatedSyncer, status: collabStatus, socket, isInRoom } = useCollaborationStore(
 		useShallow(state => ({
 			isDedicatedSyncer: state.isDedicatedSyncer,
 			status: state.status,
 			socket: state.socket as CollaborationSocket | null,
+			isInRoom: state.isInRoom,
 		})),
 	)
 
@@ -85,11 +95,31 @@ export function useSync() {
 
 	// Keep track of previously synced files to avoid resending unchanged files
 	const prevSyncedFilesRef = useRef<Record<string, string>>({})
+	const lastBroadcastedSceneHashRef = useRef<number | null>(null)
+	const broadcastedElementVersionsRef = useRef<BroadcastedElementVersions>({})
+	const hasBroadcastedSceneRef = useRef(false)
 
 	// Reset prevSyncedFilesRef when fileId changes to prevent leakage across files
 	useEffect(() => {
 		prevSyncedFilesRef.current = {}
+		lastBroadcastedSceneHashRef.current = null
+		broadcastedElementVersionsRef.current = {}
+		hasBroadcastedSceneRef.current = false
 	}, [fileId]) // Depends on fileId from the hook scope
+
+	useEffect(() => {
+		lastBroadcastedSceneHashRef.current = null
+		broadcastedElementVersionsRef.current = {}
+		hasBroadcastedSceneRef.current = false
+	}, [socket?.id])
+
+	useEffect(() => {
+		if (!isInRoom) {
+			lastBroadcastedSceneHashRef.current = null
+			broadcastedElementVersionsRef.current = {}
+			hasBroadcastedSceneRef.current = false
+		}
+	}, [isInRoom])
 
 	// --- Sync Logic ---
 
@@ -175,19 +205,49 @@ export function useSync() {
 
 	// Syncs scene and files via WebSocket
 	const doSyncViaWebSocket = useCallback(async () => {
-		if (!fileId || !excalidrawAPI || !socket || collabStatus !== 'online' || isReadOnly) {
+		if (!fileId || !excalidrawAPI || !socket || collabStatus !== 'online' || isReadOnly || !isInRoom) {
 			return
 		}
 
 		try {
 			const elements = excalidrawAPI.getSceneElementsIncludingDeleted() as readonly ExcalidrawElement[]
 			const files = excalidrawAPI.getFiles() as BinaryFiles
+			const sceneHash = computeElementVersionHash(elements)
+			let syncedElementsCount = 0
 
-			// 1. Send Scene
-			const sceneData = { type: SyncMessageType.SceneInit, payload: { elements } }
-			const sceneJson = JSON.stringify(sceneData)
-			const sceneBuffer = new TextEncoder().encode(sceneJson)
-			socket.emit(SyncMessageType.ServerBroadcast, `${fileId}`, sceneBuffer, [])
+			if (!hasBroadcastedSceneRef.current) {
+				const sceneData = { type: SyncMessageType.SceneInit, payload: { elements } }
+				const sceneBuffer = new TextEncoder().encode(JSON.stringify(sceneData))
+				socket.emit(SyncMessageType.ServerBroadcast, `${fileId}`, sceneBuffer, [])
+				hasBroadcastedSceneRef.current = true
+				lastBroadcastedSceneHashRef.current = sceneHash
+				broadcastedElementVersionsRef.current = buildBroadcastedElementVersions(elements)
+				syncedElementsCount = elements.length
+			} else if (lastBroadcastedSceneHashRef.current !== sceneHash) {
+				const incrementalElements = getIncrementalSceneElements(
+					elements,
+					broadcastedElementVersionsRef.current,
+				)
+
+				if (incrementalElements.length === 0) {
+					const sceneData = { type: SyncMessageType.SceneInit, payload: { elements } }
+					const sceneBuffer = new TextEncoder().encode(JSON.stringify(sceneData))
+					socket.emit(SyncMessageType.ServerBroadcast, `${fileId}`, sceneBuffer, [])
+					broadcastedElementVersionsRef.current = buildBroadcastedElementVersions(elements)
+					syncedElementsCount = elements.length
+				} else {
+					const sceneData = { type: SyncMessageType.SceneUpdate, payload: { elements: incrementalElements } }
+					const sceneBuffer = new TextEncoder().encode(JSON.stringify(sceneData))
+					socket.emit(SyncMessageType.ServerBroadcast, `${fileId}`, sceneBuffer, [])
+					broadcastedElementVersionsRef.current = updateBroadcastedElementVersions(
+						broadcastedElementVersionsRef.current,
+						incrementalElements,
+					)
+					syncedElementsCount = incrementalElements.length
+				}
+
+				lastBroadcastedSceneHashRef.current = sceneHash
+			}
 
 			// 2. Send only new or changed files
 			if (files && Object.keys(files).length > 0) {
@@ -205,16 +265,34 @@ export function useSync() {
 					}
 				}
 				prevSyncedFilesRef.current = currentFileHashes
-				logSyncResult('websocket', { status: 'sync success', elementsCount: elements.length })
+				logSyncResult('websocket', { status: 'sync success', elementsCount: syncedElementsCount })
 			} else {
-				logSyncResult('websocket', { status: 'sync success', elementsCount: elements.length })
+				logSyncResult('websocket', { status: 'sync success', elementsCount: syncedElementsCount })
 				prevSyncedFilesRef.current = {}
 			}
 		} catch (error) {
 			logger.error('[Sync] WebSocket sync failed:', error)
 			logSyncResult('websocket', { status: 'sync error', error: error instanceof Error ? error.message : String(error) })
 		}
-	}, [fileId, excalidrawAPI, socket, collabStatus, isReadOnly])
+	}, [fileId, excalidrawAPI, socket, collabStatus, isReadOnly, isInRoom])
+
+	const doPeriodicFullSceneHealing = useCallback(() => {
+		if (!fileId || !excalidrawAPI || !socket || collabStatus !== 'online' || isReadOnly || !isInRoom || !hasBroadcastedSceneRef.current) {
+			return
+		}
+
+		try {
+			const elements = excalidrawAPI.getSceneElementsIncludingDeleted() as readonly ExcalidrawElement[]
+			const sceneHash = computeElementVersionHash(elements)
+			const sceneData = { type: SyncMessageType.SceneUpdate, payload: { elements } }
+			const sceneBuffer = new TextEncoder().encode(JSON.stringify(sceneData))
+			socket.emit(SyncMessageType.ServerBroadcast, `${fileId}`, sceneBuffer, [])
+			lastBroadcastedSceneHashRef.current = sceneHash
+			broadcastedElementVersionsRef.current = buildBroadcastedElementVersions(elements)
+		} catch (error) {
+			logger.error('[Sync] Periodic full-scene healing failed:', error)
+		}
+	}, [fileId, excalidrawAPI, socket, collabStatus, isReadOnly, isInRoom])
 
 	const throttledSyncToLocal = useMemo(() =>
 		// Use both leading and trailing edge executions to ensure changes are saved immediately and after delay
@@ -230,6 +308,24 @@ export function useSync() {
 		// Use both leading and trailing edge executions for WebSocket sync
 		throttle(doSyncViaWebSocket, WEBSOCKET_SYNC_DELAY, { leading: true, trailing: true })
 	, [doSyncViaWebSocket])
+
+	const throttledFullSceneHealing = useMemo(() =>
+		throttle(doPeriodicFullSceneHealing, FULL_SCENE_HEALING_INTERVAL, { leading: false, trailing: true })
+	, [doPeriodicFullSceneHealing])
+
+	const flushPendingWebSocketSync = useCallback(() => {
+		if (!fileId || !excalidrawAPI || !socket || collabStatus !== 'online' || isReadOnly || !isInRoom) {
+			return
+		}
+
+		throttledSyncViaWebSocket.flush()
+	}, [fileId, excalidrawAPI, socket, collabStatus, isReadOnly, isInRoom, throttledSyncViaWebSocket])
+
+	useEffect(() => {
+		if (isInRoom && fileId && socket && collabStatus === 'online' && !isReadOnly) {
+			throttledSyncViaWebSocket()
+		}
+	}, [isInRoom, fileId, socket, collabStatus, isReadOnly, throttledSyncViaWebSocket])
 
 	// --- Cursor Sync ---
 	const doSyncCursors = useCallback(
@@ -324,6 +420,10 @@ export function useSync() {
 			const elements = excalidrawAPI.getSceneElementsIncludingDeleted()
 			const files = excalidrawAPI.getFiles()
 			cachedStateRef.current = { elements, files }
+			const sceneHash = computeElementVersionHash(elements)
+			if (sceneHash !== lastBroadcastedSceneHashRef.current) {
+				throttledFullSceneHealing()
+			}
 		}
 
 		throttledSyncToLocal()
@@ -337,7 +437,7 @@ export function useSync() {
 		}
 
 		logger.debug('[Sync] Changes detected, triggered sync operations')
-	}, [throttledSyncToLocal, throttledSyncToServerAPI, throttledSyncViaWebSocket, throttledSyncViewport, excalidrawAPI])
+	}, [throttledSyncToLocal, throttledSyncToServerAPI, throttledSyncViaWebSocket, throttledFullSceneHealing, throttledSyncViewport, excalidrawAPI])
 
 	const onPointerUpdate = useCallback(
 		(payload: {
@@ -355,11 +455,7 @@ export function useSync() {
 	// Capture syncer state immediately to avoid closure issues
 	const isSyncerRef = useRef(isDedicatedSyncer)
 	useEffect(() => {
-		if (isDedicatedSyncer !== isSyncerRef.current) {
-			// eslint-disable-next-line no-console
-			console.log('[Sync] SYNCER STATUS:', isDedicatedSyncer ? 'DESIGNATED AS SYNCER' : 'NOT SYNCER')
-			isSyncerRef.current = isDedicatedSyncer
-		}
+		isSyncerRef.current = isDedicatedSyncer
 	}, [isDedicatedSyncer])
 
 	// Cache the latest state for final sync - update on EVERY change
@@ -402,19 +498,18 @@ export function useSync() {
 			xhr.setRequestHeader('Authorization', `Bearer ${jwt}`)
 
 			xhr.send(data)
-			// eslint-disable-next-line no-console
-			console.log('[Sync] Final sync done, status:', xhr.status)
 		} catch (error) {
-			// eslint-disable-next-line no-console
-			console.error('[Sync] Final sync failed:', error)
+			logger.error('[Sync] Final sync failed:', error)
 		}
 	}, [fileId])
 
 	useEffect(() => {
 		const handleBeforeUnload = () => {
+			if (excalidrawAPI && !isReadOnly) {
+				flushPendingWebSocketSync()
+			}
+
 			if (excalidrawAPI && !isReadOnly && isSyncerRef.current) {
-				// eslint-disable-next-line no-console
-				console.log('[Sync] Page unloading - syncing as dedicated syncer')
 				// Cancel any pending throttled trailing call FIRST
 				throttledSyncToLocal.cancel()
 				throttledSyncToServerAPI.cancel()
@@ -426,7 +521,13 @@ export function useSync() {
 
 		// Also handle visibility change as backup for mobile/tabs
 		const handleVisibilityChange = () => {
-			if (document.visibilityState === 'hidden' && isSyncerRef.current && excalidrawAPI && !isReadOnly) {
+			if (document.visibilityState !== 'hidden' || !excalidrawAPI || isReadOnly) {
+				return
+			}
+
+			flushPendingWebSocketSync()
+
+			if (isSyncerRef.current) {
 				throttledSyncToLocal.cancel()
 				throttledSyncToServerAPI.cancel()
 				doSyncToLocal()
@@ -442,6 +543,10 @@ export function useSync() {
 			window.removeEventListener('beforeunload', handleBeforeUnload)
 			document.removeEventListener('visibilitychange', handleVisibilityChange)
 
+			if (excalidrawAPI && !isReadOnly) {
+				flushPendingWebSocketSync()
+			}
+
 			// If we're the dedicated syncer and unmounting, do a final sync
 			if (isSyncerRef.current && excalidrawAPI && !isReadOnly) {
 				// Cancel pending throttled calls
@@ -456,9 +561,10 @@ export function useSync() {
 			throttledSyncToLocal.cancel()
 			throttledSyncToServerAPI.cancel()
 			throttledSyncViaWebSocket.cancel()
+			throttledFullSceneHealing.cancel()
 			throttledSyncCursors.cancel()
 		}
-	}, [doSyncToLocal, doSyncToServerAPI, doFinalServerSync, throttledSyncToLocal, throttledSyncToServerAPI, throttledSyncViaWebSocket, throttledSyncCursors, excalidrawAPI, isReadOnly])
+	}, [doSyncToLocal, doSyncToServerAPI, doFinalServerSync, throttledSyncToLocal, throttledSyncToServerAPI, throttledSyncViaWebSocket, throttledFullSceneHealing, throttledSyncCursors, excalidrawAPI, isReadOnly, flushPendingWebSocketSync])
 
 	return { onChange, onPointerUpdate }
 }

--- a/src/utils/syncSceneData.ts
+++ b/src/utils/syncSceneData.ts
@@ -44,6 +44,57 @@ export const computeElementVersionHash = (
 	return hash >>> 0 // Ensure positive integer
 }
 
+export type BroadcastedElementVersion = {
+	version: number
+	versionNonce: number
+}
+
+export type BroadcastedElementVersions = Record<string, BroadcastedElementVersion>
+
+const buildElementVersionMarker = (
+	element: Pick<ExcalidrawElement, 'version' | 'versionNonce'>,
+): BroadcastedElementVersion => ({
+	version: element.version,
+	versionNonce: element.versionNonce,
+})
+
+export const buildBroadcastedElementVersions = (
+	elements: readonly ExcalidrawElement[],
+): BroadcastedElementVersions => {
+	return elements.reduce<BroadcastedElementVersions>((versions, element) => {
+		versions[element.id] = buildElementVersionMarker(element)
+		return versions
+	}, {})
+}
+
+export const updateBroadcastedElementVersions = (
+	currentVersions: BroadcastedElementVersions,
+	elements: readonly ExcalidrawElement[],
+): BroadcastedElementVersions => {
+	if (elements.length === 0) {
+		return currentVersions
+	}
+
+	const nextVersions = { ...currentVersions }
+
+	elements.forEach((element) => {
+		nextVersions[element.id] = buildElementVersionMarker(element)
+	})
+
+	return nextVersions
+}
+
+export const getIncrementalSceneElements = (
+	elements: readonly ExcalidrawElement[],
+	broadcastedElementVersions: BroadcastedElementVersions,
+): readonly ExcalidrawElement[] => {
+	return elements.filter((element) => {
+		const currentVersion = broadcastedElementVersions[element.id]
+		return currentVersion?.version !== element.version
+			|| currentVersion.versionNonce !== element.versionNonce
+	})
+}
+
 /**
  *
  * @param obj1 object 1 to compare

--- a/tests/integration/syncSceneData.spec.mjs
+++ b/tests/integration/syncSceneData.spec.mjs
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import {
+	buildBroadcastedElementVersions,
+	getIncrementalSceneElements,
+	updateBroadcastedElementVersions,
+} from '../../src/utils/syncSceneData.ts'
+
+describe('syncSceneData incremental bookkeeping', () => {
+	it('treats same version with different nonce as a new element state', () => {
+		const remoteElements = [
+			{ id: 'E1', version: 2, versionNonce: 222, isDeleted: false },
+		]
+		const localElements = [
+			{ id: 'E1', version: 2, versionNonce: 333, isDeleted: false },
+		]
+
+		const broadcastedElementVersions = buildBroadcastedElementVersions(remoteElements)
+		const incrementalElements = getIncrementalSceneElements(localElements, broadcastedElementVersions)
+
+		expect(incrementalElements).toHaveLength(1)
+		expect(incrementalElements[0].versionNonce).toBe(333)
+	})
+
+	it('only advances markers for elements that were actually sent', () => {
+		const allElements = [
+			{ id: 'A', version: 1, versionNonce: 101, isDeleted: false },
+			{ id: 'B', version: 4, versionNonce: 404, isDeleted: false },
+		]
+		const sentElements = [
+			{ id: 'A', version: 2, versionNonce: 202, isDeleted: false },
+		]
+
+		const initialMarkers = buildBroadcastedElementVersions(allElements)
+		const nextMarkers = updateBroadcastedElementVersions(initialMarkers, sentElements)
+
+		expect(nextMarkers).toEqual({
+			A: { version: 2, versionNonce: 202 },
+			B: { version: 4, versionNonce: 404 },
+		})
+	})
+})


### PR DESCRIPTION
## Problem

Whiteboard collaboration was rebroadcasting too much scene data, and incremental sync bookkeeping could miss or misclassify element updates.

## What Changed

- websocket scene sync now sends incremental `SCENE_UPDATE` payloads when only part of the scene changed
- incremental broadcast markers now track both `version` and `versionNonce`
- marker state only advances for elements that were actually transmitted
- the syncer still performs periodic full-scene healing and late-join convergence via full `SCENE_INIT` rebroadcasts
- pending websocket sync is flushed on unload / hidden / unmount so trailing edits are not dropped
- added integration coverage for incremental bookkeeping and marker updates
