### PR TITLE
benchmark incremental collaboration sync on full stack

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
         "@vitejs/plugin-react": "^5.1.4",
         "@vue/tsconfig": "^0.5.1",
         "browserslist": "^4.28.2",
+        "jsdom": "^29.0.1",
         "nodemon": "^3.1.14",
         "prettier": "^3.8.3",
         "redis-memory-server": "^0.16.0",
@@ -95,6 +96,142 @@
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.1.tgz",
+      "integrity": "sha512-iGWN8E45Ws0XWx3D44Q1t6vX2LqhCKcwfmwBYCDsFrYFS6m4q/Ks61L2veETaLv+ckDC6+dTETJoaAAb7VjLiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.1.1",
+        "@csstools/css-color-parser": "^4.0.2",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.7"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/@csstools/css-calc": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/@csstools/css-color-parser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+      "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.4.tgz",
+      "integrity": "sha512-jXR6x4AcT3eIrS2fSNAwJpwirOkGcd+E7F7CP3zjdTqz9B/2huHOL8YJZBgekKwLML+u7qB/6P1LXQuMScsx0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -417,6 +554,19 @@
       "version": "6.0.2",
       "license": "MIT"
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
     "node_modules/@buttercup/fetch": {
       "version": "0.2.1",
       "license": "MIT",
@@ -463,6 +613,26 @@
       "integrity": "sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ==",
       "license": "Apache-2.0"
     },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
     "node_modules/@csstools/css-parser-algorithms": {
       "version": "3.0.5",
       "dev": true,
@@ -483,6 +653,31 @@
       },
       "peerDependencies": {
         "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.2.tgz",
+      "integrity": "sha512-5GkLzz4prTIpoyeUiIu3iV6CSG3Plo7xRVOFPKI7FVEJ3mZ0A8SwK0XU3Gl7xAkiQ+mDyam+NNp875/C5y+jSA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
       }
     },
     "node_modules/@csstools/css-tokenizer": {
@@ -1164,6 +1359,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@file-type/xml": {
@@ -6896,6 +7109,16 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "license": "MIT",
@@ -7914,12 +8137,14 @@
       }
     },
     "node_modules/css-tree": {
-      "version": "3.1.0",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "mdn-data": "2.12.2",
-        "source-map-js": "^1.0.1"
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
@@ -8368,6 +8593,20 @@
         "node": ">= 12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "dev": true,
@@ -8469,6 +8708,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.1.0",
@@ -11167,6 +11413,19 @@
       "version": "2.0.1",
       "license": "MIT"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-tags": {
       "version": "3.3.1",
       "dev": true,
@@ -11788,6 +12047,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "license": "MIT"
@@ -12053,6 +12319,57 @@
       "peer": true,
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.1.tgz",
+      "integrity": "sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.0.1",
+        "@asamuzakjp/dom-selector": "^7.0.3",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.5",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/jsesc": {
@@ -12666,7 +12983,9 @@
       }
     },
     "node_modules/mdn-data": {
-      "version": "2.12.2",
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "dev": true,
       "license": "CC0-1.0"
     },
@@ -14026,6 +14345,32 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "license": "MIT",
@@ -14752,7 +15097,6 @@
       "version": "2.3.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -15825,6 +16169,19 @@
       "version": "1.4.1",
       "license": "ISC"
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "license": "MIT",
@@ -16748,14 +17105,6 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/stylelint-config-css-modules/node_modules/mdn-data": {
-      "version": "2.26.0",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.26.0.tgz",
-      "integrity": "sha512-ZqI0qjKWHMPcGUfLmlr80NPNVHIOjPMHtIOe1qXYFGS0YBZ1YKAzo9yk8W+gGrLCN0Xdv/RKxqdIsqPakEfmow==",
-      "dev": true,
-      "license": "CC0-1.0",
-      "optional": true
-    },
     "node_modules/stylelint-config-css-modules/node_modules/postcss-selector-parser": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
@@ -16910,12 +17259,6 @@
       "peerDependencies": {
         "stylelint": "^16.0.2"
       }
-    },
-    "node_modules/stylelint-scss/node_modules/mdn-data": {
-      "version": "2.21.0",
-      "dev": true,
-      "license": "CC0-1.0",
-      "peer": true
     },
     "node_modules/stylelint-scss/node_modules/postcss-selector-parser": {
       "version": "7.1.0",
@@ -17145,6 +17488,13 @@
         "@svgmoji/twemoji": "^3.2.0"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tabbable": {
       "version": "6.2.0",
       "license": "MIT"
@@ -17350,6 +17700,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.27",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.27.tgz",
+      "integrity": "sha512-I4FZcVFcqCRuT0ph6dCDpPuO4Xgzvh+spkcTr1gK7peIvxWauoloVO0vuy1FQnijT63ss6AsHB6+OIM4aXHbPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.27"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.27",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.27.tgz",
+      "integrity": "sha512-YQ7uPjgWUibIK6DW5lrKujGwUKhLevU4hcGbP5O6TcIUb+oTjJYJVWPS4nZsIHrEEEG6myk/oqAJUEQmpZrHsg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tmp": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
@@ -17400,6 +17770,32 @@
       "license": "ISC",
       "bin": {
         "nodetouch": "bin/nodetouch.js"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tributejs": {
@@ -17723,6 +18119,16 @@
       "version": "2.0.5",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.6.tgz",
+      "integrity": "sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
@@ -18486,6 +18892,29 @@
         "vue": "^2.5.0"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/w3c-xmlserializer/node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/wait-on": {
       "version": "9.0.1",
       "dev": true,
@@ -18598,9 +19027,44 @@
       "integrity": "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==",
       "license": "Apache-2.0"
     },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/webworkify": {
       "version": "1.5.0",
       "license": "MIT"
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -18808,6 +19272,13 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xmlhttprequest-ssl": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "server:start": "node websocket_server/main.js",
     "server:watch": "nodemon websocket_server/main.js",
     "test": "vitest run",
+    "bench:incremental-sync": "node tools/benchmarks/runIncrementalSyncBenchmark.mjs",
     "test:watch": "vitest",
     "start:nextcloud": "node playwright/start-nextcloud-server.mjs"
   },

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@vitejs/plugin-react": "^5.1.4",
     "@vue/tsconfig": "^0.5.1",
     "browserslist": "^4.28.2",
+    "jsdom": "^29.0.1",
     "nodemon": "^3.1.14",
     "prettier": "^3.8.3",
     "redis-memory-server": "^0.16.0",

--- a/playwright/bench/incremental-sync-benchmark.spec.ts
+++ b/playwright/bench/incremental-sync-benchmark.spec.ts
@@ -1,0 +1,402 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import type { Browser, Page } from '@playwright/test'
+import { expect } from '@playwright/test'
+import { test } from '../support/fixtures/random-user'
+import {
+	benchmarkMutations,
+	benchmarkScenarios,
+	formatBytes,
+	selectMutations,
+	selectScenarios,
+	type BenchmarkMutation,
+	type BenchmarkScenario,
+	type MutationPlan,
+} from '../support/incrementalSyncBenchmarkFixtures'
+import {
+	clearReceivedSceneMessages,
+	clearCapturedSceneMessages,
+	enableWhiteboardTestHooks,
+	getCapturedSceneMessages,
+	getReceivedSceneMessages,
+	getScenePayloadBytes,
+	installSceneEmitSpy,
+	installSceneReceiveSpy,
+	waitForCollaborationReady,
+	waitForSceneElementCount,
+} from '../support/incrementalSyncBenchmarkHooks'
+import {
+	addTextElement,
+	captureBoardAuthFromSave,
+	createWhiteboard,
+	fetchBoardContent,
+	newLoggedInPage,
+	openFilesApp,
+	openWhiteboardById,
+	resolveFileIdByDav,
+} from '../support/utils'
+
+type BenchmarkConfig = {
+	scenarios: string[]
+	mutations: string[]
+	scale: number
+	runs: number
+	outputPath: string | null
+}
+
+type BenchmarkSample = {
+	totalElements: number
+	plannedChangedElements: number
+	changedElements: number
+	bootstrapBytes: number
+	fullUpdateBytes: number
+	incrementalBytes: number
+	lateJoinReadyMs: number
+	incrementalEmitMs: number
+	remoteApplyMs: number
+}
+
+type BenchmarkRow = {
+	scenario: string
+	mutation: string
+	runs: number
+	totalElements: number
+	plannedChangedElements: number
+	changedElements: number
+	bootstrapBytes: number
+	fullUpdateBytes: number
+	incrementalBytes: number
+	reductionPercent: string
+	lateJoinReadyMs: string
+	incrementalEmitMs: string
+	remoteApplyMs: string
+}
+
+const benchmarkEnabled = process.env.WHITEBOARD_INCREMENTAL_SYNC_BENCH === '1'
+
+function parseCsvEnv(name: string, fallback: string[]) {
+	const raw = process.env[name]
+	if (!raw) {
+		return fallback
+	}
+	return raw.split(',').map((value) => value.trim()).filter(Boolean)
+}
+
+function parseIntegerEnv(name: string, fallback: number) {
+	const raw = process.env[name]
+	if (!raw) {
+		return fallback
+	}
+	const value = parseInt(raw, 10)
+	return Number.isFinite(value) && value > 0 ? value : fallback
+}
+
+function readConfig(): BenchmarkConfig {
+	return {
+		scenarios: parseCsvEnv('SYNC_BENCH_SCENARIOS', benchmarkScenarios.map((scenario) => scenario.key)),
+		mutations: parseCsvEnv('SYNC_BENCH_MUTATIONS', benchmarkMutations.map((mutation) => mutation.key)),
+		scale: parseIntegerEnv('SYNC_BENCH_SCALE', 1),
+		runs: parseIntegerEnv('SYNC_BENCH_RUNS', 1),
+		outputPath: process.env.SYNC_BENCH_OUTPUT_PATH?.trim() || null,
+	}
+}
+
+function median(values: number[]) {
+	const sorted = [...values].sort((a, b) => a - b)
+	const middle = Math.floor(sorted.length / 2)
+	if (sorted.length % 2 === 0) {
+		return (sorted[middle - 1] + sorted[middle]) / 2
+	}
+	return sorted[middle]
+}
+
+function formatMs(value: number) {
+	return value.toFixed(1)
+}
+
+function aggregateSamples(
+	scenario: BenchmarkScenario,
+	mutation: BenchmarkMutation,
+	runs: number,
+	samples: BenchmarkSample[],
+): BenchmarkRow {
+	const bootstrapBytes = median(samples.map((sample) => sample.bootstrapBytes))
+	const fullUpdateBytes = median(samples.map((sample) => sample.fullUpdateBytes))
+	const incrementalBytes = median(samples.map((sample) => sample.incrementalBytes))
+	const reductionPercent = fullUpdateBytes > 0
+		? ((1 - (incrementalBytes / fullUpdateBytes)) * 100).toFixed(2)
+		: '0.00'
+
+	return {
+		scenario: scenario.label,
+		mutation: mutation.label,
+		runs,
+		totalElements: samples[0].totalElements,
+		plannedChangedElements: samples[0].plannedChangedElements,
+		changedElements: Math.round(median(samples.map((sample) => sample.changedElements))),
+		bootstrapBytes: Math.round(bootstrapBytes),
+		fullUpdateBytes: Math.round(fullUpdateBytes),
+		incrementalBytes: Math.round(incrementalBytes),
+		reductionPercent,
+		lateJoinReadyMs: formatMs(median(samples.map((sample) => sample.lateJoinReadyMs))),
+		incrementalEmitMs: formatMs(median(samples.map((sample) => sample.incrementalEmitMs))),
+		remoteApplyMs: formatMs(median(samples.map((sample) => sample.remoteApplyMs))),
+	}
+}
+
+async function waitForSceneMessage(page: Page, matcher: { transport: 'room' | 'direct', type: 'SCENE_INIT' | 'SCENE_UPDATE', emittedAtOrAfter: number }) {
+	await page.waitForFunction((expected) => {
+		const win = window as any
+		const messages = win.__whiteboardTestHooks?.benchmarkSceneMessages || []
+		return messages.some((message: any) => (
+			message.transport === expected.transport
+			&& message.type === expected.type
+			&& Number(message.emittedAt) >= expected.emittedAtOrAfter
+		))
+	}, matcher, { timeout: 60_000 })
+
+	const messages = await getCapturedSceneMessages(page)
+	const match = messages.find((message) => (
+		message.transport === matcher.transport
+		&& message.type === matcher.type
+		&& message.emittedAt >= matcher.emittedAtOrAfter
+	))
+	if (!match) {
+		throw new Error(`Missing ${matcher.transport} ${matcher.type} message`)
+	}
+	return match
+}
+
+async function waitForReceivedSceneMessage(page: Page, matcher: { type: 'SCENE_INIT' | 'SCENE_UPDATE', receivedAtOrAfter: number }) {
+	await page.waitForFunction((expected) => {
+		const win = window as any
+		const messages = win.__whiteboardTestHooks?.benchmarkReceivedSceneMessages || []
+		return messages.some((message: any) => (
+			message.type === expected.type
+			&& Number(message.receivedAt) >= expected.receivedAtOrAfter
+		))
+	}, matcher, { timeout: 60_000 })
+
+	const messages = await getReceivedSceneMessages(page)
+	const match = messages.find((message) => (
+		message.type === matcher.type
+		&& message.receivedAt >= matcher.receivedAtOrAfter
+	))
+	if (!match) {
+		throw new Error(`Missing received ${matcher.type} message`)
+	}
+	return match
+}
+
+async function applyMutation(page: Page, mutationPlan: MutationPlan) {
+	await page.evaluate((elements) => {
+		const win = window as any
+		const api = win.__whiteboardTestHooks?.excalidrawStore?.getState?.().excalidrawAPI
+		if (!api?.updateScene) {
+			throw new Error('Excalidraw API not available')
+		}
+		api.updateScene({ elements })
+	}, mutationPlan.elements)
+}
+
+async function seedBoardContent(
+	page: Page,
+	auth: { fileId: number, jwt: string },
+	sceneData: { elements: MutationPlan['elements'], files?: Record<string, unknown>, appState?: Record<string, unknown> },
+) {
+	const response = await page.request.put(`apps/whiteboard/${auth.fileId}`, {
+		headers: {
+			Authorization: auth.jwt.startsWith('Bearer ') ? auth.jwt : `Bearer ${auth.jwt}`,
+			'Content-Type': 'application/json',
+			'X-Requested-With': 'XMLHttpRequest',
+		},
+		data: {
+			data: {
+				elements: sceneData.elements,
+				files: sceneData.files || {},
+				appState: sceneData.appState || {},
+			},
+		},
+	})
+	expect(response.ok()).toBeTruthy()
+}
+
+async function runBenchmarkSample(
+	page: Page,
+	browser: Browser,
+	scenario: BenchmarkScenario,
+	mutation: BenchmarkMutation,
+	scale: number,
+	runNumber: number,
+) {
+	const boardName = `Bench ${scenario.key} ${mutation.key} ${Date.now()} ${runNumber}`
+	const fixture = scenario.build(scale)
+	const mutationPlan = mutation.apply(fixture, scale)
+
+	await openFilesApp(page)
+	await enableWhiteboardTestHooks(page)
+	await createWhiteboard(page, { name: boardName })
+	await waitForCollaborationReady(page)
+	const authCaptureText = `bench auth ${Date.now()}`
+	const authPromise = captureBoardAuthFromSave(page, { containsText: authCaptureText })
+	await addTextElement(page, authCaptureText)
+	const fileId = await resolveFileIdByDav(page, boardName)
+	if (!fileId) {
+		throw new Error(`Failed to resolve file id for ${boardName}`)
+	}
+	const auth = await authPromise
+	await seedBoardContent(page, auth, { elements: fixture.elements })
+	const persistedBoard = await fetchBoardContent(page, auth)
+
+	const persistedFixture = {
+		...fixture,
+		elements: Array.isArray((persistedBoard as any).elements) ? (persistedBoard as any).elements : fixture.elements,
+	}
+	const persistedMutationPlan = mutation.apply(persistedFixture, scale)
+
+	const syncerPage = await newLoggedInPage(page, browser)
+	try {
+		await enableWhiteboardTestHooks(syncerPage)
+		await openWhiteboardById(syncerPage, fileId)
+		await waitForCollaborationReady(syncerPage)
+		await waitForSceneElementCount(syncerPage, persistedFixture.elements.length)
+		await syncerPage.waitForTimeout(800)
+		await installSceneEmitSpy(syncerPage)
+		await installSceneReceiveSpy(syncerPage)
+		await clearCapturedSceneMessages(syncerPage)
+		await clearReceivedSceneMessages(syncerPage)
+
+		const pageB = await newLoggedInPage(page, browser)
+		try {
+			await enableWhiteboardTestHooks(pageB)
+			const bootstrapStartedAt = Date.now()
+			await openWhiteboardById(pageB, auth.fileId)
+			await waitForCollaborationReady(pageB)
+
+			const bootstrapMessage = await waitForSceneMessage(syncerPage, {
+				transport: 'direct',
+				type: 'SCENE_INIT',
+				emittedAtOrAfter: bootstrapStartedAt,
+			})
+			const lateJoinReadyMs = bootstrapMessage.emittedAt - bootstrapStartedAt
+			const bootstrapSettleMs = Math.min(1_200 + persistedFixture.elements.length * 5, 4_000)
+			await pageB.waitForTimeout(bootstrapSettleMs)
+
+			await installSceneEmitSpy(pageB)
+			await clearCapturedSceneMessages(pageB)
+			await clearReceivedSceneMessages(syncerPage)
+
+			const mutationStartedAt = Date.now()
+			await applyMutation(pageB, persistedMutationPlan)
+
+			const incrementalMessage = await waitForSceneMessage(pageB, {
+				transport: 'room',
+				type: 'SCENE_UPDATE',
+				emittedAtOrAfter: mutationStartedAt,
+			})
+			const incrementalEmitMs = incrementalMessage.emittedAt - mutationStartedAt
+
+			const receivedMessage = await waitForReceivedSceneMessage(syncerPage, {
+				type: 'SCENE_UPDATE',
+				receivedAtOrAfter: mutationStartedAt,
+			})
+			const remoteApplyMs = receivedMessage.receivedAt - mutationStartedAt
+
+			const fullUpdateBytes = await getScenePayloadBytes(pageB, 'SCENE_UPDATE')
+
+			expect(incrementalMessage.syncAll).toBe(false)
+			expect(receivedMessage.syncAll).toBe(false)
+			expect(receivedMessage.elementsCount).toBe(incrementalMessage.elementsCount)
+
+			return {
+				totalElements: persistedMutationPlan.elements.length,
+				plannedChangedElements: persistedMutationPlan.changedElements,
+				changedElements: incrementalMessage.elementsCount,
+				bootstrapBytes: bootstrapMessage.payloadBytes,
+				fullUpdateBytes,
+				incrementalBytes: incrementalMessage.payloadBytes,
+				lateJoinReadyMs,
+				incrementalEmitMs,
+				remoteApplyMs,
+			} satisfies BenchmarkSample
+		} finally {
+			await pageB.context().close()
+		}
+	} finally {
+		await syncerPage.context().close()
+	}
+}
+
+test.skip(!benchmarkEnabled, 'full-stack benchmark runner only')
+test.describe.configure({ mode: 'serial' })
+
+test('runs the incremental sync benchmark against the real Nextcloud stack', async ({ page, browser }) => {
+	test.setTimeout(30 * 60 * 1000)
+
+	const config = readConfig()
+	const selectedScenarios = selectScenarios(config.scenarios)
+	const selectedMutations = selectMutations(config.mutations)
+	const rows: BenchmarkRow[] = []
+
+	for (const scenario of selectedScenarios) {
+		for (const mutation of selectedMutations) {
+			const samples: BenchmarkSample[] = []
+			for (let run = 1; run <= config.runs; run += 1) {
+				console.log(`BENCHMARK_CASE|scenario=${scenario.key}|mutation=${mutation.key}|run=${run}/${config.runs}`)
+				samples.push(await runBenchmarkSample(page, browser, scenario, mutation, config.scale, run))
+			}
+			rows.push(aggregateSamples(scenario, mutation, config.runs, samples))
+		}
+	}
+
+	console.table(rows.map((row) => ({
+		scenario: row.scenario,
+		mutation: row.mutation,
+		runs: row.runs,
+		totalElements: row.totalElements,
+		plannedChangedElements: row.plannedChangedElements,
+		changedElements: row.changedElements,
+		bootstrapPayload: formatBytes(row.bootstrapBytes),
+		fullPayload: formatBytes(row.fullUpdateBytes),
+		incrementalPayload: formatBytes(row.incrementalBytes),
+		reduction: `${row.reductionPercent}%`,
+		lateJoinReadyMs: row.lateJoinReadyMs,
+		incrementalEmitMs: row.incrementalEmitMs,
+		remoteApplyMs: row.remoteApplyMs,
+	})))
+
+	rows.forEach((row) => {
+		console.log([
+			'BENCHMARK_RESULT',
+			`scenario=${row.scenario}`,
+			`mutation=${row.mutation}`,
+			`runs=${row.runs}`,
+			`total_elements=${row.totalElements}`,
+			`planned_changed_elements=${row.plannedChangedElements}`,
+			`changed_elements=${row.changedElements}`,
+			`bootstrap_bytes=${row.bootstrapBytes}`,
+			`full_update_bytes=${row.fullUpdateBytes}`,
+			`incremental_bytes=${row.incrementalBytes}`,
+			`reduction_percent=${row.reductionPercent}`,
+			`late_join_ready_ms=${row.lateJoinReadyMs}`,
+			`incremental_emit_ms=${row.incrementalEmitMs}`,
+			`remote_apply_ms=${row.remoteApplyMs}`,
+		].join('|'))
+	})
+
+	if (config.outputPath) {
+		const outputPath = resolve(config.outputPath)
+		mkdirSync(dirname(outputPath), { recursive: true })
+		writeFileSync(outputPath, JSON.stringify({
+			timestamp: new Date().toISOString(),
+			config,
+			rows,
+		}, null, 2))
+		console.log(`BENCHMARK_OUTPUT|path=${outputPath}`)
+	}
+})

--- a/playwright/e2e/collaboration.spec.ts
+++ b/playwright/e2e/collaboration.spec.ts
@@ -3,53 +3,371 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 import { expect } from '@playwright/test'
+import type { Page } from '@playwright/test'
 import { test } from '../support/fixtures/random-user'
 import {
 	addTextElement,
 	createWhiteboard,
 	newLoggedInPage,
+	openWhiteboardById,
 	openFilesApp,
-	openWhiteboardFromFiles,
-	fetchBoardContent,
-	getBoardAuth,
+	resolveFileIdByDav,
 } from '../support/utils'
+
+type CapturedSceneMessage = {
+	transport: 'room' | 'direct'
+	type: string
+	syncAll: boolean
+	elementsCount: number
+}
+
+type ReceivedSceneMessage = {
+	type: string
+	syncAll: boolean
+	elementsCount: number
+}
+
+type CollaborationSocketHook = {
+	connected?: boolean
+	emit: (eventName: string, ...args: unknown[]) => unknown
+}
+
+type WhiteboardTestHooks = {
+	collaborationStore?: {
+		getState?: () => {
+			socket?: CollaborationSocketHook
+			isInRoom?: boolean
+		}
+	}
+	excalidrawStore?: {
+		getState?: () => {
+			excalidrawAPI?: {
+				getSceneElementsIncludingDeleted?: () => Array<{
+					type?: string
+					text?: string
+					isDeleted?: boolean
+				}>
+			}
+		}
+	}
+	emittedSceneMessages?: CapturedSceneMessage[]
+	receivedSceneMessages?: ReceivedSceneMessage[]
+	sceneEmitSpyInstalled?: boolean
+	sceneReceiveSpyInstalled?: boolean
+}
+
+type WhiteboardTestWindow = Window & {
+	__whiteboardTest?: boolean
+	__whiteboardTestHooks?: WhiteboardTestHooks
+}
+
+async function enableWhiteboardTestHooks(page: Page) {
+	await page.addInitScript(() => {
+		const win = window as WhiteboardTestWindow
+		win.__whiteboardTest = true
+		win.__whiteboardTestHooks = win.__whiteboardTestHooks || {}
+		win.__whiteboardTestHooks.emittedSceneMessages = []
+		win.__whiteboardTestHooks.receivedSceneMessages = []
+	})
+	await page.evaluate(() => {
+		const win = window as WhiteboardTestWindow
+		win.__whiteboardTest = true
+		win.__whiteboardTestHooks = win.__whiteboardTestHooks || {}
+		win.__whiteboardTestHooks.emittedSceneMessages = win.__whiteboardTestHooks.emittedSceneMessages || []
+		win.__whiteboardTestHooks.receivedSceneMessages = win.__whiteboardTestHooks.receivedSceneMessages || []
+	})
+}
+
+async function waitForCollaborationReady(page: Page) {
+	await page.waitForFunction(() => {
+		const win = window as WhiteboardTestWindow
+		const store = win.__whiteboardTestHooks?.collaborationStore
+		const state = store?.getState?.()
+		return Boolean(state?.socket?.connected && state?.isInRoom)
+	}, { timeout: 30000 })
+}
+
+async function installSceneEmitSpy(page: Page) {
+	await waitForCollaborationReady(page)
+	await page.evaluate(() => {
+		const win = window as WhiteboardTestWindow
+		win.__whiteboardTestHooks = win.__whiteboardTestHooks || {}
+		const hooks = win.__whiteboardTestHooks
+		hooks.emittedSceneMessages = hooks.emittedSceneMessages || []
+		if (hooks.sceneEmitSpyInstalled) {
+			return
+		}
+
+		const store = hooks.collaborationStore
+		const socket = store?.getState?.().socket
+		if (!socket) {
+			throw new Error('Collaboration socket not available')
+		}
+
+		const decodePayload = (payload: unknown) => {
+			if (typeof payload === 'string') {
+				return payload
+			}
+			if (payload instanceof ArrayBuffer) {
+				return new TextDecoder().decode(new Uint8Array(payload))
+			}
+			if (ArrayBuffer.isView(payload)) {
+				return new TextDecoder().decode(
+					new Uint8Array(payload.buffer, payload.byteOffset, payload.byteLength),
+				)
+			}
+			return ''
+		}
+
+		const originalEmit = socket.emit.bind(socket)
+		socket.emit = (eventName: string, ...args: unknown[]) => {
+			if (eventName === 'server-broadcast' || eventName === 'server-direct-broadcast') {
+				const decoded = decodePayload(eventName === 'server-direct-broadcast' ? args[2] : args[1])
+				if (decoded) {
+					try {
+						const parsed = JSON.parse(decoded)
+						if (parsed?.type === 'SCENE_INIT' || parsed?.type === 'SCENE_UPDATE') {
+							hooks.emittedSceneMessages?.push({
+								transport: eventName === 'server-direct-broadcast' ? 'direct' : 'room',
+								type: parsed.type,
+								syncAll: parsed.payload?.syncAll === true,
+								elementsCount: Array.isArray(parsed.payload?.elements)
+									? parsed.payload.elements.length
+									: 0,
+							})
+						}
+					} catch {
+						// Ignore frames that are not JSON scene payloads.
+					}
+				}
+			}
+			return originalEmit(eventName, ...args)
+		}
+
+		hooks.sceneEmitSpyInstalled = true
+	})
+}
+
+async function clearCapturedSceneMessages(page: Page) {
+	await page.evaluate(() => {
+		const win = window as WhiteboardTestWindow
+		const messages = win.__whiteboardTestHooks?.emittedSceneMessages
+		if (messages) {
+			messages.length = 0
+		} else if (win.__whiteboardTestHooks) {
+			win.__whiteboardTestHooks.emittedSceneMessages = []
+		}
+	})
+}
+
+async function getCapturedSceneMessages(page: Page): Promise<CapturedSceneMessage[]> {
+	return page.evaluate(() => {
+		const win = window as WhiteboardTestWindow
+		return win.__whiteboardTestHooks?.emittedSceneMessages || []
+	})
+}
+
+async function installSceneReceiveSpy(page: Page) {
+	await waitForCollaborationReady(page)
+	await page.evaluate(() => {
+		const win = window as WhiteboardTestWindow
+		win.__whiteboardTestHooks = win.__whiteboardTestHooks || {}
+		const hooks = win.__whiteboardTestHooks
+		hooks.receivedSceneMessages = hooks.receivedSceneMessages || []
+		if (hooks.sceneReceiveSpyInstalled) {
+			return
+		}
+
+		const store = hooks.collaborationStore
+		const socket = store?.getState?.().socket
+		if (!socket) {
+			throw new Error('Collaboration socket not available')
+		}
+
+		const decodePayload = (payload: unknown) => {
+			if (typeof payload === 'string') {
+				return payload
+			}
+			if (payload instanceof ArrayBuffer) {
+				return new TextDecoder().decode(new Uint8Array(payload))
+			}
+			if (ArrayBuffer.isView(payload)) {
+				return new TextDecoder().decode(
+					new Uint8Array(payload.buffer, payload.byteOffset, payload.byteLength),
+				)
+			}
+			return ''
+		}
+
+		socket.onAny((eventName: string, ...args: unknown[]) => {
+			if (eventName !== 'client-broadcast') {
+				return
+			}
+
+			const decoded = decodePayload(args[0])
+			if (!decoded) {
+				return
+			}
+
+			try {
+				const parsed = JSON.parse(decoded)
+				if (parsed?.type === 'SCENE_INIT' || parsed?.type === 'SCENE_UPDATE') {
+					hooks.receivedSceneMessages?.push({
+						type: parsed.type,
+						syncAll: parsed.payload?.syncAll === true,
+						elementsCount: Array.isArray(parsed.payload?.elements)
+							? parsed.payload.elements.length
+							: 0,
+					})
+				}
+			} catch {
+				// Ignore frames that are not JSON scene payloads.
+			}
+		})
+
+		hooks.sceneReceiveSpyInstalled = true
+	})
+}
+
+async function clearReceivedSceneMessages(page: Page) {
+	await page.evaluate(() => {
+		const win = window as WhiteboardTestWindow
+		const messages = win.__whiteboardTestHooks?.receivedSceneMessages
+		if (messages) {
+			messages.length = 0
+		} else if (win.__whiteboardTestHooks) {
+			win.__whiteboardTestHooks.receivedSceneMessages = []
+		}
+	})
+}
+
+async function getReceivedSceneMessages(page: Page): Promise<ReceivedSceneMessage[]> {
+	return page.evaluate(() => {
+		const win = window as WhiteboardTestWindow
+		return win.__whiteboardTestHooks?.receivedSceneMessages || []
+	})
+}
+
+async function resolveBoardFileId(page: Page, boardName: string): Promise<string> {
+	await expect.poll(async () => resolveFileIdByDav(page, boardName), {
+		timeout: 30000,
+		intervals: [500],
+	}).not.toBeNull()
+
+	const fileId = await resolveFileIdByDav(page, boardName)
+	if (!fileId) {
+		throw new Error(`Failed to resolve file id for board: ${boardName}`)
+	}
+	return fileId
+}
 
 test.beforeEach(async ({ page }) => {
 	await openFilesApp(page)
 })
 
-test('whiteboard changes sync across sessions', async ({ page, browser, user }) => {
+test('whiteboard changes sync across sessions', async ({ page, browser }) => {
 	test.setTimeout(90000)
 	const boardName = `Collab board ${Date.now()}`
 
+	await enableWhiteboardTestHooks(page)
 	await createWhiteboard(page, { name: boardName })
 	await addTextElement(page, 'First session text')
-
-	let auth
-	try {
-		auth = await getBoardAuth(page)
-	} catch {
-		const saveResp = await page.waitForResponse((response) => response.request().method() === 'PUT' && response.url().includes('/apps/whiteboard/'), { timeout: 60000 })
-		const authHeader = saveResp.request().headers()['authorization'] || ''
-		const apiPath = new URL(saveResp.url()).pathname.replace('/index.php/', '')
-		const fileId = Number(apiPath.split('/').pop())
-		auth = { fileId, jwt: authHeader }
-	}
-
-	await expect.poll(async () => JSON.stringify(await fetchBoardContent(page, auth)), {
-		timeout: 20000,
-		interval: 500,
-	}).toContain('First session text')
+	const fileId = await resolveBoardFileId(page, boardName)
+	await installSceneReceiveSpy(page)
+	await clearReceivedSceneMessages(page)
 
 	const pageB = await newLoggedInPage(page, browser)
-	await openWhiteboardFromFiles(pageB, boardName)
-	const fetchContent = async (targetPage) => JSON.stringify(await fetchBoardContent(targetPage, auth))
-
-	await expect.poll(async () => fetchContent(pageB), { timeout: 20000, interval: 500 }).toContain('First session text')
+	await enableWhiteboardTestHooks(pageB)
+	await openWhiteboardById(pageB, fileId)
 
 	await addTextElement(pageB, 'Second session text')
+	await page.waitForFunction(() => {
+		const win = window as WhiteboardTestWindow
+		const messages = win.__whiteboardTestHooks?.receivedSceneMessages || []
+		return messages.some((message: ReceivedSceneMessage) => (
+			message.type === 'SCENE_UPDATE'
+			&& message.syncAll === false
+			&& message.elementsCount === 1
+		))
+	}, { timeout: 30000 })
 
-	await expect.poll(async () => fetchContent(page), { timeout: 30000, interval: 500 }).toContain('Second session text')
+	const receivedMessages = await getReceivedSceneMessages(page)
+	expect(receivedMessages.some((message) => (
+		message.type === 'SCENE_UPDATE'
+		&& message.syncAll === false
+		&& message.elementsCount === 1
+	))).toBe(true)
+
+	await pageB.close()
+})
+
+test('incremental scene sync sends only changed elements after targeted bootstrap', async ({ page, browser }) => {
+	test.setTimeout(120000)
+	const boardName = `Incremental collab board ${Date.now()}`
+	const bootstrapText = 'Incremental bootstrap text'
+	const deltaText = 'Incremental delta text'
+
+	await enableWhiteboardTestHooks(page)
+	await createWhiteboard(page, { name: boardName })
+	await addTextElement(page, bootstrapText)
+	const fileId = await resolveBoardFileId(page, boardName)
+	await installSceneEmitSpy(page)
+	await clearCapturedSceneMessages(page)
+	await installSceneReceiveSpy(page)
+	await clearReceivedSceneMessages(page)
+
+	const pageB = await newLoggedInPage(page, browser)
+	await enableWhiteboardTestHooks(pageB)
+	await openWhiteboardById(pageB, fileId)
+
+	await page.waitForFunction(() => {
+		const win = window as WhiteboardTestWindow
+		const messages = win.__whiteboardTestHooks?.emittedSceneMessages || []
+		return messages.some((message: CapturedSceneMessage) => (
+			message.transport === 'direct'
+			&& message.type === 'SCENE_INIT'
+		))
+	}, { timeout: 30000 })
+
+	const bootstrapMessages = await getCapturedSceneMessages(page)
+	expect(bootstrapMessages.some((message) => (
+		message.transport === 'direct'
+		&& message.type === 'SCENE_INIT'
+	))).toBe(true)
+	expect(bootstrapMessages.some((message) => (
+		message.transport === 'room'
+		&& message.type === 'SCENE_INIT'
+	))).toBe(false)
+
+	await installSceneEmitSpy(pageB)
+	await clearCapturedSceneMessages(pageB)
+
+	await addTextElement(pageB, deltaText)
+
+	await pageB.waitForFunction(() => {
+		const win = window as WhiteboardTestWindow
+		const messages = win.__whiteboardTestHooks?.emittedSceneMessages || []
+		return messages.some((message: { type?: string, syncAll?: boolean, elementsCount?: number }) => (
+			message.type === 'SCENE_UPDATE'
+			&& message.syncAll === false
+			&& message.elementsCount === 1
+		))
+	}, { timeout: 30000 })
+
+	const messages = await getCapturedSceneMessages(pageB)
+	const incrementalMessages = messages.filter((message) => message.type === 'SCENE_UPDATE')
+	const receivedMessages = await getReceivedSceneMessages(page)
+
+	expect(incrementalMessages.length).toBeGreaterThan(0)
+	expect(incrementalMessages.some((message) => message.syncAll)).toBe(false)
+	expect(incrementalMessages.every((message) => message.transport === 'room')).toBe(true)
+	expect(messages.some((message) => message.type === 'SCENE_INIT')).toBe(false)
+	expect(incrementalMessages.every((message) => message.elementsCount === 1)).toBe(true)
+	expect(receivedMessages.some((message) => (
+		message.type === 'SCENE_UPDATE'
+		&& message.syncAll === false
+		&& message.elementsCount === 1
+	))).toBe(true)
 
 	await pageB.close()
 })

--- a/playwright/support/incrementalSyncBenchmarkFixtures.ts
+++ b/playwright/support/incrementalSyncBenchmarkFixtures.ts
@@ -1,0 +1,562 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+export type BenchElement = Record<string, unknown> & {
+	id: string
+	type: string
+	version: number
+	versionNonce: number
+	isDeleted: boolean
+	updated: number
+	x?: number
+	y?: number
+	width?: number
+	height?: number
+}
+
+export type ElementSnapshot = {
+	id: string
+	type: string
+	version: number
+	isDeleted: boolean
+	text?: string
+	originalText?: string
+	x?: number
+	y?: number
+}
+
+export type SceneFixture = {
+	elements: BenchElement[]
+	textIds: string[]
+	clusterIds: string[][]
+	connectorIds: string[]
+	frameIds: string[]
+}
+
+export type BenchmarkScenario = {
+	key: string
+	label: string
+	build: (scale: number) => SceneFixture
+}
+
+export type MutationPlan = {
+	label: string
+	changedElements: number
+	changedElementIds: string[]
+	elements: BenchElement[]
+	expectedElements: ElementSnapshot[]
+}
+
+export type BenchmarkMutation = {
+	key: string
+	label: string
+	apply: (fixture: SceneFixture, scale: number) => MutationPlan
+}
+
+const BASE_TIMESTAMP = 1_710_000_000_000
+
+function nextNonce(index: number) {
+	return 10_000 + index * 31
+}
+
+function baseElement(
+	id: string,
+	type: string,
+	index: number,
+	x: number,
+	y: number,
+	width: number,
+	height: number,
+	extras: Record<string, unknown> = {},
+): BenchElement {
+	return {
+		id,
+		type,
+		x,
+		y,
+		width,
+		height,
+		angle: 0,
+		strokeColor: '#1f2937',
+		backgroundColor: 'transparent',
+		fillStyle: 'solid',
+		strokeWidth: 1,
+		strokeStyle: 'solid',
+		roughness: 0,
+		opacity: 100,
+		groupIds: [],
+		frameId: null,
+		roundness: null,
+		seed: index + 1,
+		version: 1,
+		versionNonce: nextNonce(index),
+		isDeleted: false,
+		boundElements: null,
+		updated: BASE_TIMESTAMP + index,
+		link: null,
+		locked: false,
+		...extras,
+	}
+}
+
+function textElement(id: string, index: number, x: number, y: number, text: string, extras: Record<string, unknown> = {}): BenchElement {
+	return baseElement(id, 'text', index, x, y, 220, 48, {
+		text,
+		originalText: text,
+		fontSize: 20,
+		fontFamily: 1,
+		textAlign: 'left',
+		verticalAlign: 'top',
+		containerId: null,
+		lineHeight: 1.25,
+		baseline: 18,
+		...extras,
+	})
+}
+
+function rectangleElement(id: string, index: number, x: number, y: number, width: number, height: number, extras: Record<string, unknown> = {}): BenchElement {
+	return baseElement(id, 'rectangle', index, x, y, width, height, {
+		backgroundColor: '#fef3c7',
+		strokeColor: '#92400e',
+		roundness: { type: 3 },
+		...extras,
+	})
+}
+
+function frameElement(id: string, index: number, x: number, y: number, width: number, height: number, name: string): BenchElement {
+	return baseElement(id, 'frame', index, x, y, width, height, {
+		name,
+		backgroundColor: '#fffaf0',
+		strokeColor: '#c2410c',
+	})
+}
+
+function lineElement(id: string, index: number, x: number, y: number, points: Array<[number, number]>, extras: Record<string, unknown> = {}): BenchElement {
+	return baseElement(id, 'line', index, x, y, 0, 0, {
+		points,
+		lastCommittedPoint: points[points.length - 1] || null,
+		startBinding: null,
+		endBinding: null,
+		...extras,
+	})
+}
+
+function arrowElement(id: string, index: number, x: number, y: number, points: Array<[number, number]>, extras: Record<string, unknown> = {}): BenchElement {
+	return baseElement(id, 'arrow', index, x, y, 0, 0, {
+		points,
+		lastCommittedPoint: points[points.length - 1] || null,
+		startBinding: null,
+		endBinding: null,
+		startArrowhead: null,
+		endArrowhead: 'triangle',
+		...extras,
+	})
+}
+
+function cloneElements(elements: readonly BenchElement[]) {
+	return elements.map((element) => structuredClone(element))
+}
+
+function touchElements(elements: BenchElement[], ids: Iterable<string>, patch: (element: BenchElement, index: number) => BenchElement) {
+	const idSet = new Set(ids)
+	let touched = 0
+	return elements.map((element) => {
+		if (!idSet.has(element.id)) {
+			return element
+		}
+		touched += 1
+		return patch(element, touched)
+	})
+}
+
+function moveElements(elements: BenchElement[], ids: Iterable<string>, dx: number, dy: number) {
+	return touchElements(elements, ids, (element, order) => ({
+		...element,
+		x: typeof element.x === 'number' ? element.x + dx : element.x,
+		y: typeof element.y === 'number' ? element.y + dy : element.y,
+		version: element.version + 1,
+		versionNonce: element.versionNonce + 1_000 + order,
+		updated: element.updated + 30_000 + order,
+	}))
+}
+
+function editTextElements(elements: BenchElement[], ids: Iterable<string>, suffix: string) {
+	return touchElements(elements, ids, (element, order) => {
+		if (element.type !== 'text') {
+			return {
+				...element,
+				version: element.version + 1,
+				versionNonce: element.versionNonce + 500 + order,
+				updated: element.updated + 20_000 + order,
+			}
+		}
+
+		const nextText = `${String(element.text || element.originalText || '')}${suffix}`
+		return {
+			...element,
+			text: nextText,
+			originalText: nextText,
+			version: element.version + 1,
+			versionNonce: element.versionNonce + 500 + order,
+			updated: element.updated + 20_000 + order,
+		}
+	})
+}
+
+function rerouteConnectors(elements: BenchElement[], ids: Iterable<string>, offset: number) {
+	return touchElements(elements, ids, (element, order) => {
+		const points = Array.isArray(element.points)
+			? (element.points as Array<[number, number]>).map(([x, y], pointIndex) => [
+				x + offset + pointIndex,
+				y + offset - pointIndex,
+			])
+			: element.points
+		return {
+			...element,
+			points,
+			lastCommittedPoint: Array.isArray(points) ? points[points.length - 1] : element.lastCommittedPoint,
+			version: element.version + 1,
+			versionNonce: element.versionNonce + 2_000 + order,
+			updated: element.updated + 15_000 + order,
+		}
+	})
+}
+
+function markDeleted(elements: BenchElement[], ids: Iterable<string>) {
+	return touchElements(elements, ids, (element, order) => ({
+		...element,
+		isDeleted: true,
+		version: element.version + 1,
+		versionNonce: element.versionNonce + 3_000 + order,
+		updated: element.updated + 10_000 + order,
+	}))
+}
+
+function toSnapshots(elements: readonly BenchElement[], ids: Iterable<string>) {
+	const idSet = new Set(ids)
+	return elements
+		.filter((element) => idSet.has(element.id))
+		.map((element) => ({
+			id: element.id,
+			type: element.type,
+			version: element.version,
+			isDeleted: element.isDeleted,
+			text: typeof element.text === 'string' ? element.text : undefined,
+			originalText: typeof element.originalText === 'string' ? element.originalText : undefined,
+			x: typeof element.x === 'number' ? element.x : undefined,
+			y: typeof element.y === 'number' ? element.y : undefined,
+		}))
+}
+
+function buildRetroBoard(scale: number): SceneFixture {
+	const columnCount = 4
+	const notesPerColumn = 24 * scale
+	const elements: BenchElement[] = []
+	const textIds: string[] = []
+	const clusterIds: string[][] = []
+	const connectorIds: string[] = []
+	const frameIds: string[] = []
+	let index = 0
+
+	for (let column = 0; column < columnCount; column += 1) {
+		const frameId = `retro-frame-${column}`
+		frameIds.push(frameId)
+		elements.push(frameElement(frameId, index++, 80 + column * 360, 80, 320, 1_160, `Lane ${column + 1}`))
+
+		for (let note = 0; note < notesPerColumn; note += 1) {
+			const baseX = 110 + column * 360
+			const baseY = 140 + note * 44
+			const rectId = `retro-note-${column}-${note}`
+			const textId = `retro-text-${column}-${note}`
+			textIds.push(textId)
+			elements.push(rectangleElement(rectId, index++, baseX, baseY, 260, 36, { frameId }))
+			elements.push(textElement(textId, index++, baseX + 18, baseY + 10, `Retro note ${column + 1}.${note + 1}`, {
+				containerId: rectId,
+				frameId,
+			}))
+
+			if (note % 6 === 0) {
+				const ids: string[] = []
+				for (let offset = 0; offset < 6 && note + offset < notesPerColumn; offset += 1) {
+					ids.push(`retro-note-${column}-${note + offset}`, `retro-text-${column}-${note + offset}`)
+				}
+				clusterIds.push(ids)
+			}
+		}
+	}
+
+	for (let column = 0; column < columnCount - 1; column += 1) {
+		for (let row = 0; row < Math.max(6, 6 * scale); row += 1) {
+			const connectorId = `retro-link-${column}-${row}`
+			connectorIds.push(connectorId)
+			elements.push(arrowElement(
+				connectorId,
+				index++,
+				330 + column * 360,
+				190 + row * 170,
+				[[0, 0], [160, 10]],
+				{ frameId: null, strokeColor: '#ea580c' },
+			))
+		}
+	}
+
+	return {
+		elements,
+		textIds,
+		clusterIds,
+		connectorIds,
+		frameIds,
+	}
+}
+
+function buildPlanningFlow(scale: number): SceneFixture {
+	const stageCount = 6
+	const nodesPerStage = 18 * scale
+	const elements: BenchElement[] = []
+	const textIds: string[] = []
+	const clusterIds: string[][] = []
+	const connectorIds: string[] = []
+	const frameIds: string[] = []
+	let index = 0
+
+	for (let stage = 0; stage < stageCount; stage += 1) {
+		const frameId = `flow-frame-${stage}`
+		frameIds.push(frameId)
+		elements.push(frameElement(frameId, index++, 70 + stage * 280, 70, 240, 1_260, `Stage ${stage + 1}`))
+
+		for (let node = 0; node < nodesPerStage; node += 1) {
+			const x = 100 + stage * 280
+			const y = 130 + node * 62
+			const shapeId = `flow-shape-${stage}-${node}`
+			const textId = `flow-text-${stage}-${node}`
+			const isDecision = node % 5 === 0
+			textIds.push(textId)
+			elements.push(baseElement(shapeId, isDecision ? 'diamond' : 'rectangle', index++, x, y, 180, 44, {
+				frameId,
+				backgroundColor: isDecision ? '#dbeafe' : '#dcfce7',
+				strokeColor: isDecision ? '#2563eb' : '#15803d',
+				roundness: isDecision ? null : { type: 3 },
+			}))
+			elements.push(textElement(textId, index++, x + 16, y + 12, `Step ${stage + 1}.${node + 1}`, {
+				containerId: shapeId,
+				frameId,
+			}))
+
+			if (node < nodesPerStage - 1) {
+				const connectorId = `flow-link-${stage}-${node}`
+				connectorIds.push(connectorId)
+				elements.push(arrowElement(connectorId, index++, x + 90, y + 44, [[0, 0], [0, 18]], {
+					frameId,
+					strokeColor: '#64748b',
+				}))
+			}
+		}
+
+		for (let block = 0; block < nodesPerStage; block += 6) {
+			const ids: string[] = []
+			for (let offset = 0; offset < 6 && block + offset < nodesPerStage; offset += 1) {
+				ids.push(`flow-shape-${stage}-${block + offset}`, `flow-text-${stage}-${block + offset}`)
+				if (block + offset < nodesPerStage - 1) {
+					ids.push(`flow-link-${stage}-${block + offset}`)
+				}
+			}
+			clusterIds.push(ids)
+		}
+	}
+
+	for (let stage = 0; stage < stageCount - 1; stage += 1) {
+		for (let row = 0; row < Math.max(8, 8 * scale); row += 1) {
+			const connectorId = `flow-cross-link-${stage}-${row}`
+			connectorIds.push(connectorId)
+			elements.push(arrowElement(
+				connectorId,
+				index++,
+				250 + stage * 280,
+				180 + row * 120,
+				[[0, 0], [140, 0]],
+				{ strokeColor: '#0f766e' },
+			))
+		}
+	}
+
+	return {
+		elements,
+		textIds,
+		clusterIds,
+		connectorIds,
+		frameIds,
+	}
+}
+
+function buildMediaReview(scale: number): SceneFixture {
+	const laneCount = 3
+	const itemsPerLane = 14 * scale
+	const elements: BenchElement[] = []
+	const textIds: string[] = []
+	const clusterIds: string[][] = []
+	const connectorIds: string[] = []
+	const frameIds: string[] = []
+	let index = 0
+
+	for (let lane = 0; lane < laneCount; lane += 1) {
+		const frameId = `media-frame-${lane}`
+		frameIds.push(frameId)
+		elements.push(frameElement(frameId, index++, 80 + lane * 470, 70, 410, 1_240, `Review lane ${lane + 1}`))
+
+		for (let item = 0; item < itemsPerLane; item += 1) {
+			const baseX = 110 + lane * 470
+			const baseY = 130 + item * 78
+			const cardId = `media-card-${lane}-${item}`
+			const captionId = `media-caption-${lane}-${item}`
+			const commentId = `media-comment-${lane}-${item}`
+			textIds.push(captionId, commentId)
+			elements.push(rectangleElement(cardId, index++, baseX, baseY, 220, 64, {
+				frameId,
+				backgroundColor: '#dbeafe',
+				strokeColor: '#1d4ed8',
+			}))
+			elements.push(textElement(captionId, index++, baseX + 242, baseY + 8, `Asset ${lane + 1}.${item + 1} caption`, {
+				frameId,
+			}))
+			elements.push(textElement(commentId, index++, baseX + 242, baseY + 40, `Reviewer note ${lane + 1}.${item + 1}`, {
+				frameId,
+				fontSize: 16,
+				height: 32,
+			}))
+
+			const connectorId = `media-link-${lane}-${item}`
+			connectorIds.push(connectorId)
+			elements.push(lineElement(connectorId, index++, baseX + 220, baseY + 30, [[0, 0], [20, 0], [20, 18]], {
+				frameId,
+				strokeColor: '#7c3aed',
+			}))
+
+			if (item % 4 === 0) {
+				const ids: string[] = []
+				for (let offset = 0; offset < 4 && item + offset < itemsPerLane; offset += 1) {
+					ids.push(
+						`media-card-${lane}-${item + offset}`,
+						`media-caption-${lane}-${item + offset}`,
+						`media-comment-${lane}-${item + offset}`,
+						`media-link-${lane}-${item + offset}`,
+					)
+				}
+				clusterIds.push(ids)
+			}
+		}
+	}
+
+	return {
+		elements,
+		textIds,
+		clusterIds,
+		connectorIds,
+		frameIds,
+	}
+}
+
+export const benchmarkScenarios: BenchmarkScenario[] = [
+	{ key: 'retro-board', label: 'retro board', build: buildRetroBoard },
+	{ key: 'planning-flow', label: 'planning flow', build: buildPlanningFlow },
+	{ key: 'media-review', label: 'media review', build: buildMediaReview },
+]
+
+export const benchmarkMutations: BenchmarkMutation[] = [
+	{
+		key: 'single-text-edit',
+		label: 'single text edit',
+		apply: (fixture) => {
+			const changedElementIds = [fixture.textIds[0]]
+			const elements = editTextElements(cloneElements(fixture.elements), changedElementIds, ' updated')
+			return {
+				label: 'single text edit',
+				changedElements: 1,
+				changedElementIds,
+				expectedElements: toSnapshots(elements, changedElementIds),
+				elements,
+			}
+		},
+	},
+	{
+		key: 'selection-drag',
+		label: 'selection drag',
+		apply: (fixture, scale) => {
+			const changedElementIds = fixture.clusterIds[0] || fixture.textIds.slice(0, 8 * scale)
+			const elements = moveElements(cloneElements(fixture.elements), changedElementIds, 96, 48)
+			return {
+				label: 'selection drag',
+				changedElements: changedElementIds.length,
+				changedElementIds,
+				expectedElements: toSnapshots(elements, changedElementIds),
+				elements,
+			}
+		},
+	},
+	{
+		key: 'mixed-session-burst',
+		label: 'mixed session burst',
+		apply: (fixture, scale) => {
+			let elements = cloneElements(fixture.elements)
+			const editedTextIds = fixture.textIds.slice(0, Math.max(6, 6 * scale))
+			const movedClusterIds = fixture.clusterIds.flat().slice(0, Math.max(18, 18 * scale))
+			const reroutedConnectorIds = fixture.connectorIds.slice(0, Math.max(8, 8 * scale))
+			const deletedIds = fixture.textIds.slice(-Math.max(2, 2 * scale))
+			elements = editTextElements(elements, editedTextIds, ' revised')
+			elements = moveElements(elements, movedClusterIds, 72, 36)
+			elements = rerouteConnectors(elements, reroutedConnectorIds, 12)
+			elements = markDeleted(elements, deletedIds)
+
+			const nextIndex = elements.length + 1
+			const addedElements: BenchElement[] = [
+				arrowElement(`added-arrow-${scale}-1`, nextIndex, 180, 180, [[0, 0], [120, 30]], { strokeColor: '#dc2626' }),
+				arrowElement(`added-arrow-${scale}-2`, nextIndex + 1, 360, 320, [[0, 0], [90, -24]], { strokeColor: '#dc2626' }),
+				textElement(`added-text-${scale}-1`, nextIndex + 2, 240, 140, 'New follow-up action'),
+			]
+			elements.push(...addedElements)
+
+			const changedElementIds = Array.from(new Set([
+				...editedTextIds,
+				...movedClusterIds,
+				...reroutedConnectorIds,
+				...deletedIds,
+				...addedElements.map((element) => element.id),
+			]))
+
+			return {
+				label: 'mixed session burst',
+				changedElements: changedElementIds.length,
+				changedElementIds,
+				expectedElements: toSnapshots(elements, changedElementIds),
+				elements,
+			}
+		},
+	},
+]
+
+export function selectScenarios(keys: string[]) {
+	const selected = benchmarkScenarios.filter((scenario) => keys.includes(scenario.key))
+	if (selected.length === 0) {
+		throw new Error(`Unknown scenario selection: ${keys.join(', ')}`)
+	}
+	return selected
+}
+
+export function selectMutations(keys: string[]) {
+	const selected = benchmarkMutations.filter((mutation) => keys.includes(mutation.key))
+	if (selected.length === 0) {
+		throw new Error(`Unknown mutation selection: ${keys.join(', ')}`)
+	}
+	return selected
+}
+
+export function formatBytes(bytes: number) {
+	if (bytes >= 1_000_000) {
+		return `${(bytes / 1_000_000).toFixed(2)} MB`
+	}
+	if (bytes >= 1_000) {
+		return `${(bytes / 1_000).toFixed(1)} KB`
+	}
+	return `${bytes} B`
+}

--- a/playwright/support/incrementalSyncBenchmarkHooks.ts
+++ b/playwright/support/incrementalSyncBenchmarkHooks.ts
@@ -1,0 +1,346 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Page } from '@playwright/test'
+import type { ElementSnapshot } from './incrementalSyncBenchmarkFixtures'
+
+type CapturedSceneMessage = {
+	transport: 'room' | 'direct'
+	type: string
+	syncAll: boolean
+	elementsCount: number
+	payloadBytes: number
+	emittedAt: number
+}
+
+type ReceivedSceneMessage = {
+	type: string
+	syncAll: boolean
+	elementsCount: number
+	payloadBytes: number
+	receivedAt: number
+}
+
+type CollaborationSocketHook = {
+	connected?: boolean
+	emit: (eventName: string, ...args: unknown[]) => unknown
+}
+
+type WhiteboardTestHooks = {
+	collaborationStore?: {
+		getState?: () => {
+			socket?: CollaborationSocketHook
+			isInRoom?: boolean
+		}
+	}
+	excalidrawStore?: {
+		getState?: () => {
+			excalidrawAPI?: {
+				getSceneElementsIncludingDeleted?: () => Array<Record<string, unknown>>
+				updateScene?: (scene: Record<string, unknown>) => void
+			}
+		}
+	}
+	benchmarkSceneMessages?: CapturedSceneMessage[]
+	benchmarkSceneEmitSpyInstalled?: boolean
+	benchmarkReceivedSceneMessages?: ReceivedSceneMessage[]
+	benchmarkSceneReceiveSpyInstalled?: boolean
+}
+
+type WhiteboardTestWindow = Window & {
+	__whiteboardTest?: boolean
+	__whiteboardTestHooks?: WhiteboardTestHooks
+}
+
+export async function enableWhiteboardTestHooks(page: Page) {
+	await page.addInitScript(() => {
+		const win = window as WhiteboardTestWindow
+		win.__whiteboardTest = true
+		win.__whiteboardTestHooks = win.__whiteboardTestHooks || {}
+		win.__whiteboardTestHooks.benchmarkSceneMessages = []
+		win.__whiteboardTestHooks.benchmarkReceivedSceneMessages = []
+	})
+
+	await page.evaluate(() => {
+		const win = window as WhiteboardTestWindow
+		win.__whiteboardTest = true
+		win.__whiteboardTestHooks = win.__whiteboardTestHooks || {}
+		win.__whiteboardTestHooks.benchmarkSceneMessages = win.__whiteboardTestHooks.benchmarkSceneMessages || []
+		win.__whiteboardTestHooks.benchmarkReceivedSceneMessages = win.__whiteboardTestHooks.benchmarkReceivedSceneMessages || []
+	})
+}
+
+export async function waitForCollaborationReady(page: Page) {
+	await page.waitForFunction(() => {
+		const win = window as WhiteboardTestWindow
+		const store = win.__whiteboardTestHooks?.collaborationStore
+		const state = store?.getState?.()
+		return Boolean(state?.socket?.connected && state?.isInRoom)
+	}, { timeout: 60_000 })
+}
+
+export async function installSceneEmitSpy(page: Page) {
+	await waitForCollaborationReady(page)
+	await page.evaluate(() => {
+		const win = window as WhiteboardTestWindow
+		win.__whiteboardTestHooks = win.__whiteboardTestHooks || {}
+		const hooks = win.__whiteboardTestHooks
+		hooks.benchmarkSceneMessages = hooks.benchmarkSceneMessages || []
+		if (hooks.benchmarkSceneEmitSpyInstalled) {
+			return
+		}
+
+		const socket = hooks.collaborationStore?.getState?.().socket
+		if (!socket) {
+			throw new Error('Collaboration socket not available')
+		}
+
+		const encoder = new TextEncoder()
+		const bytesForPayload = (payload: unknown) => {
+			if (typeof payload === 'string') {
+				return encoder.encode(payload).byteLength
+			}
+			if (payload instanceof ArrayBuffer) {
+				return payload.byteLength
+			}
+			if (ArrayBuffer.isView(payload)) {
+				return payload.byteLength
+			}
+			if (payload) {
+				return encoder.encode(JSON.stringify(payload)).byteLength
+			}
+			return 0
+		}
+
+		const decodePayload = (payload: unknown) => {
+			if (typeof payload === 'string') {
+				return payload
+			}
+			if (payload instanceof ArrayBuffer) {
+				return new TextDecoder().decode(new Uint8Array(payload))
+			}
+			if (ArrayBuffer.isView(payload)) {
+				return new TextDecoder().decode(
+					new Uint8Array(payload.buffer, payload.byteOffset, payload.byteLength),
+				)
+			}
+			return ''
+		}
+
+		const originalEmit = socket.emit.bind(socket)
+		socket.emit = (eventName: string, ...args: unknown[]) => {
+			if (eventName === 'server-broadcast' || eventName === 'server-direct-broadcast') {
+				const rawPayload = eventName === 'server-direct-broadcast' ? args[2] : args[1]
+				const decoded = decodePayload(rawPayload)
+				if (decoded) {
+					try {
+						const parsed = JSON.parse(decoded)
+						if (parsed?.type === 'SCENE_INIT' || parsed?.type === 'SCENE_UPDATE') {
+							hooks.benchmarkSceneMessages?.push({
+								transport: eventName === 'server-direct-broadcast' ? 'direct' : 'room',
+								type: parsed.type,
+								syncAll: parsed.payload?.syncAll === true,
+								elementsCount: Array.isArray(parsed.payload?.elements) ? parsed.payload.elements.length : 0,
+								payloadBytes: bytesForPayload(rawPayload),
+								emittedAt: Date.now(),
+							})
+						}
+					} catch {
+						// Ignore non-scene payloads.
+					}
+				}
+			}
+			return originalEmit(eventName, ...args)
+		}
+
+		hooks.benchmarkSceneEmitSpyInstalled = true
+	})
+}
+
+export async function clearCapturedSceneMessages(page: Page) {
+	await page.evaluate(() => {
+		const win = window as WhiteboardTestWindow
+		const messages = win.__whiteboardTestHooks?.benchmarkSceneMessages
+		if (messages) {
+			messages.length = 0
+		}
+	})
+}
+
+export async function getCapturedSceneMessages(page: Page): Promise<CapturedSceneMessage[]> {
+	return page.evaluate(() => {
+		const win = window as WhiteboardTestWindow
+		return win.__whiteboardTestHooks?.benchmarkSceneMessages || []
+	})
+}
+
+export async function installSceneReceiveSpy(page: Page) {
+	await waitForCollaborationReady(page)
+	await page.evaluate(() => {
+		const win = window as WhiteboardTestWindow
+		win.__whiteboardTestHooks = win.__whiteboardTestHooks || {}
+		const hooks = win.__whiteboardTestHooks
+		hooks.benchmarkReceivedSceneMessages = hooks.benchmarkReceivedSceneMessages || []
+		if (hooks.benchmarkSceneReceiveSpyInstalled) {
+			return
+		}
+
+		const socket = hooks.collaborationStore?.getState?.().socket
+		if (!socket) {
+			throw new Error('Collaboration socket not available')
+		}
+
+		const encoder = new TextEncoder()
+		const bytesForPayload = (payload: unknown) => {
+			if (typeof payload === 'string') {
+				return encoder.encode(payload).byteLength
+			}
+			if (payload instanceof ArrayBuffer) {
+				return payload.byteLength
+			}
+			if (ArrayBuffer.isView(payload)) {
+				return payload.byteLength
+			}
+			if (payload) {
+				return encoder.encode(JSON.stringify(payload)).byteLength
+			}
+			return 0
+		}
+
+		const decodePayload = (payload: unknown) => {
+			if (typeof payload === 'string') {
+				return payload
+			}
+			if (payload instanceof ArrayBuffer) {
+				return new TextDecoder().decode(new Uint8Array(payload))
+			}
+			if (ArrayBuffer.isView(payload)) {
+				return new TextDecoder().decode(
+					new Uint8Array(payload.buffer, payload.byteOffset, payload.byteLength),
+				)
+			}
+			return ''
+		}
+
+		socket.onAny((eventName: string, ...args: unknown[]) => {
+			if (eventName !== 'client-broadcast') {
+				return
+			}
+
+			const decoded = decodePayload(args[0])
+			if (!decoded) {
+				return
+			}
+
+			try {
+				const parsed = JSON.parse(decoded)
+				if (parsed?.type === 'SCENE_INIT' || parsed?.type === 'SCENE_UPDATE') {
+					hooks.benchmarkReceivedSceneMessages?.push({
+						type: parsed.type,
+						syncAll: parsed.payload?.syncAll === true,
+						elementsCount: Array.isArray(parsed.payload?.elements) ? parsed.payload.elements.length : 0,
+						payloadBytes: bytesForPayload(args[0]),
+						receivedAt: Date.now(),
+					})
+				}
+			} catch {
+				// Ignore non-scene payloads.
+			}
+		})
+
+		hooks.benchmarkSceneReceiveSpyInstalled = true
+	})
+}
+
+export async function clearReceivedSceneMessages(page: Page) {
+	await page.evaluate(() => {
+		const win = window as WhiteboardTestWindow
+		const messages = win.__whiteboardTestHooks?.benchmarkReceivedSceneMessages
+		if (messages) {
+			messages.length = 0
+		}
+	})
+}
+
+export async function getReceivedSceneMessages(page: Page): Promise<ReceivedSceneMessage[]> {
+	return page.evaluate(() => {
+		const win = window as WhiteboardTestWindow
+		return win.__whiteboardTestHooks?.benchmarkReceivedSceneMessages || []
+	})
+}
+
+export async function injectScene(page: Page, elements: Array<Record<string, unknown>>) {
+	await waitForCollaborationReady(page)
+	await page.evaluate((sceneElements) => {
+		const win = window as WhiteboardTestWindow
+		const api = win.__whiteboardTestHooks?.excalidrawStore?.getState?.().excalidrawAPI
+		if (!api?.updateScene) {
+			throw new Error('Excalidraw API not available')
+		}
+		api.updateScene({ elements: sceneElements })
+	}, elements)
+}
+
+export async function waitForSceneElementCount(page: Page, expectedCount: number, timeout = 60_000) {
+	await page.waitForFunction((count) => {
+		const win = window as WhiteboardTestWindow
+		const api = win.__whiteboardTestHooks?.excalidrawStore?.getState?.().excalidrawAPI
+		const elements = api?.getSceneElementsIncludingDeleted?.() || []
+		return elements.length === count
+	}, expectedCount, { timeout })
+}
+
+export async function waitForElementSnapshots(page: Page, expectedElements: ElementSnapshot[], timeout = 60_000) {
+	await page.waitForFunction((snapshots) => {
+		const win = window as WhiteboardTestWindow
+		const api = win.__whiteboardTestHooks?.excalidrawStore?.getState?.().excalidrawAPI
+		const elements = api?.getSceneElementsIncludingDeleted?.() || []
+		if (!elements.length) {
+			return false
+		}
+
+		const current = new Map(elements.map((element) => [String(element.id), element]))
+		return snapshots.every((snapshot) => {
+			const element = current.get(snapshot.id)
+			if (!element) {
+				return false
+			}
+			if (Number(element.version) !== snapshot.version) {
+				return false
+			}
+			if (Boolean(element.isDeleted) !== snapshot.isDeleted) {
+				return false
+			}
+			if (snapshot.type === 'text') {
+				const currentText = String(element.text ?? element.originalText ?? '')
+				const expectedText = String(snapshot.text ?? snapshot.originalText ?? '')
+				if (currentText !== expectedText) {
+					return false
+				}
+			}
+			return true
+		})
+	}, expectedElements, { timeout })
+}
+
+export async function getScenePayloadBytes(page: Page, type: 'SCENE_INIT' | 'SCENE_UPDATE') {
+	return page.evaluate((messageType) => {
+		const win = window as WhiteboardTestWindow
+		const api = win.__whiteboardTestHooks?.excalidrawStore?.getState?.().excalidrawAPI
+		const elements = api?.getSceneElementsIncludingDeleted?.() || []
+		return new TextEncoder().encode(JSON.stringify({
+			type: messageType,
+			payload: { elements },
+		})).byteLength
+	}, type)
+}
+
+export async function getSceneElements(page: Page) {
+	return page.evaluate(() => {
+		const win = window as WhiteboardTestWindow
+		const api = win.__whiteboardTestHooks?.excalidrawStore?.getState?.().excalidrawAPI
+		return api?.getSceneElementsIncludingDeleted?.() || []
+	})
+}

--- a/playwright/support/utils.ts
+++ b/playwright/support/utils.ts
@@ -65,7 +65,12 @@ export async function createWhiteboard(page: Page, { name }: { name?: string } =
 		await waitForCanvas(page, { timeout: 20000 })
 	} catch (error) {
 		await openFilesApp(page)
-		await openWhiteboardFromFiles(page, boardName)
+		const resolvedFileId = await resolveFileIdByDav(page, boardName)
+		if (resolvedFileId) {
+			await openWhiteboardById(page, resolvedFileId)
+		} else {
+			await openWhiteboardFromFiles(page, boardName)
+		}
 	}
 
 	return boardName
@@ -345,7 +350,7 @@ export async function openWhiteboardById(
 	await waitForCanvas(page)
 }
 
-async function resolveFileIdByDav(page: Page, name: string): Promise<string | null> {
+export async function resolveFileIdByDav(page: Page, name: string): Promise<string | null> {
 	const origin = new URL(await page.url()).origin
 	const userResponse = await page.request.get(`${origin}/ocs/v2.php/cloud/user?format=json`, {
 		headers: { 'OCS-APIREQUEST': 'true' },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ import { translate as t } from '@nextcloud/l10n'
 import { loadState } from '@nextcloud/initial-state'
 import { Excalidraw as ExcalidrawComponent, useHandleLibrary, Sidebar, isElementLink } from '@nextcloud/excalidraw'
 import '@excalidraw/excalidraw/index.css'
-import type { LibraryItems } from '@nextcloud/excalidraw/dist/types/excalidraw/types'
+import type { AppState, BinaryFiles, LibraryItems } from '@nextcloud/excalidraw/dist/types/excalidraw/types'
 import { useExcalidrawStore } from './stores/useExcalidrawStore'
 import { useWhiteboardConfigStore } from './stores/useWhiteboardConfigStore'
 import { useThemeHandling } from './hooks/useThemeHandling'
@@ -439,12 +439,12 @@ export default function App({
 		return Array.from({ length: 40 }, () => Math.floor(Math.random() * 16).toString(16)).join('')
 	}, [maxImageSizeBytes, maxImageSizeMb])
 
-	const handleOnChange = useCallback(() => {
+	const handleOnChange = useCallback((elements: readonly ExcalidrawElement[], appState: AppState, files: BinaryFiles) => {
 		if (isVersionPreview) {
 			return
 		}
 		if (!excalidrawAPI || !normalizedFileId || isLoading) return
-		onChangeSync()
+		onChangeSync(elements, appState, files)
 	}, [excalidrawAPI, normalizedFileId, isLoading, onChangeSync, isVersionPreview])
 
 	const canvasActions = useMemo(() => {

--- a/src/hooks/useCollaboration.ts
+++ b/src/hooks/useCollaboration.ts
@@ -14,7 +14,7 @@ import type {
 	Collaborator,
 	ExcalidrawImageElement,
 } from '@excalidraw/excalidraw/types/types'
-import { restoreElements } from '@nextcloud/excalidraw'
+import { CaptureUpdateAction, restoreElements } from '@nextcloud/excalidraw'
 import { loadState } from '@nextcloud/initial-state'
 import { mergeElementsWithMetadata } from '../utils/mergeElementsWithMetadata'
 import { io } from 'socket.io-client'
@@ -26,11 +26,13 @@ import { sanitizeAppStateForSync } from '../utils/sanitizeAppState'
 import { useShallow } from 'zustand/react/shallow'
 import { throttle, debounce } from 'lodash'
 import { db } from '../database/db'
-import { computeElementVersionHash } from '../utils/syncSceneData'
+import { buildBroadcastedElementVersions, computeElementVersionHash, mergeSceneElements } from '../utils/syncSceneData'
 import type { ClientToServerEvents, CollaborationSocket, ServerToClientEvents } from '../types/collaboration'
 
 enum BroadcastType {
 	SceneInit = 'SCENE_INIT', // Incoming scene data from others
+	SceneInitRequest = 'SCENE_INIT_REQUEST', // Request targeted bootstrap from current syncer
+	SceneUpdate = 'SCENE_UPDATE', // Incremental scene data from others
 	SceneRestore = 'SCENE_RESTORE', // Force replace scene from authoritative source
 	MouseLocation = 'MOUSE_LOCATION', // Incoming cursor data
 	ImageAdd = 'IMAGE_ADD', // Incoming image data from others
@@ -39,10 +41,11 @@ enum BroadcastType {
 }
 
 const CURSOR_UPDATE_DELAY = 50
+type DisconnectCallback = () => void
 
 export function useCollaboration() {
 	const joinedRoomRef = useRef<string | null>(null)
-	const pendingSceneUpdateRef = useRef<readonly ExcalidrawElement[] | null>(null)
+	const pendingSceneUpdatesRef = useRef<readonly ExcalidrawElement[][]>([])
 	const pendingImageUpdatesRef = useRef<Map<string, BinaryFileData>>(new Map())
 	const pendingSceneReplaceRef = useRef<{
 		elements: ExcalidrawElement[]
@@ -81,6 +84,9 @@ export function useCollaboration() {
 		setStatus,
 		setSocket,
 		setDedicatedSyncer,
+		replaceBroadcastedElementVersions,
+		mergeBroadcastedElementVersions,
+		resetSceneSyncState,
 		incrementAuthFailure,
 		clearAuthError,
 		resetStore, // Use resetStore for full cleanup
@@ -90,6 +96,9 @@ export function useCollaboration() {
 			setStatus: state.setStatus,
 			setSocket: state.setSocket,
 			setDedicatedSyncer: state.setDedicatedSyncer,
+			replaceBroadcastedElementVersions: state.replaceBroadcastedElementVersions,
+			mergeBroadcastedElementVersions: state.mergeBroadcastedElementVersions,
+			resetSceneSyncState: state.resetSceneSyncState,
 			incrementAuthFailure: state.incrementAuthFailure,
 			clearAuthError: state.clearAuthError,
 			resetStore: state.resetStore,
@@ -98,41 +107,58 @@ export function useCollaboration() {
 	)
 
 	// --- Remote Update Handlers ---
+	const requestMissingImages = useCallback((remoteElements: readonly ExcalidrawElement[]) => {
+		if (!excalidrawAPI) return
+
+		const currentFiles = excalidrawAPI.getFiles()
+		const currentSocket = useCollaborationStore.getState().socket
+
+		if (!currentSocket?.connected || !fileId) {
+			return
+		}
+
+		const missingImages = remoteElements
+			.filter(el => el.type === 'image'
+				&& (el as ExcalidrawImageElement).fileId
+				&& !currentFiles[(el as ExcalidrawImageElement).fileId])
+
+		missingImages.forEach(el => {
+			const imageId = (el as ExcalidrawImageElement).fileId
+			console.log(`[Collaboration] Requesting missing image: ${imageId}`)
+			currentSocket.emit('image-get', `${fileId}`, imageId)
+		})
+	}, [excalidrawAPI, fileId])
+
 	const reconcileAndApplyRemoteElements = useCallback(
 		(remoteElements: readonly ExcalidrawElement[]) => {
 			if (!excalidrawAPI) return
 
 			try {
-				// Restore and reconcile elements
 				const restoredRemoteElements = restoreElements(remoteElements, null)
 				const localElements = excalidrawAPI.getSceneElementsIncludingDeleted() || []
 				const appState = excalidrawAPI.getAppState()
 				const reconciledElements = mergeElementsWithMetadata(localElements, restoredRemoteElements, appState)
-				excalidrawAPI.updateScene({ elements: reconciledElements })
+				const localSceneHash = computeElementVersionHash(localElements)
+				const reconciledHash = computeElementVersionHash(reconciledElements)
+				const remoteVersions = buildBroadcastedElementVersions(restoredRemoteElements)
 
-				// Request any missing images
-				const currentFiles = excalidrawAPI.getFiles()
-				const currentSocket = useCollaborationStore.getState().socket
-
-				if (currentSocket?.connected && fileId) {
-					// Find image elements with missing file data
-					const missingImages = restoredRemoteElements
-						.filter(el => el.type === 'image'
-							&& (el as ExcalidrawImageElement).fileId
-							&& !currentFiles[(el as ExcalidrawImageElement).fileId])
-
-					// Request each missing image
-					missingImages.forEach(el => {
-						const imageId = (el as ExcalidrawImageElement).fileId
-						console.log(`[Collaboration] Requesting missing image: ${imageId}`)
-						currentSocket.emit('image-get', `${fileId}`, imageId)
-					})
+				if (localSceneHash === reconciledHash) {
+					mergeBroadcastedElementVersions(remoteVersions)
+					requestMissingImages(restoredRemoteElements)
+					return
 				}
+
+				mergeBroadcastedElementVersions(remoteVersions)
+				excalidrawAPI.updateScene({
+					elements: reconciledElements,
+					captureUpdate: CaptureUpdateAction.NEVER,
+				})
+				requestMissingImages(restoredRemoteElements)
 			} catch (error) {
 				console.error('[Collaboration] Error reconciling remote elements:', error)
 			}
 		},
-		[excalidrawAPI, fileId],
+		[excalidrawAPI, mergeBroadcastedElementVersions, requestMissingImages],
 	)
 
 	const handleRemoteImageAdd = useCallback(
@@ -158,7 +184,14 @@ export function useCollaboration() {
 	const queueSceneUpdate = useCallback(
 		(remoteElements: readonly ExcalidrawElement[]) => {
 			if (!excalidrawAPI) {
-				pendingSceneUpdateRef.current = remoteElements
+				const restoredRemoteElements = restoreElements(remoteElements, null)
+				pendingSceneUpdatesRef.current = pendingSceneUpdatesRef.current.length === 0
+					? [restoredRemoteElements]
+					: [mergeSceneElements(
+						pendingSceneUpdatesRef.current[0],
+						restoredRemoteElements,
+						{} as AppState,
+					)]
 				return
 			}
 
@@ -191,6 +224,7 @@ export function useCollaboration() {
 			}
 
 			try {
+				replaceBroadcastedElementVersions(buildBroadcastedElementVersions(payload.elements))
 				excalidrawAPI.resetScene()
 
 				const currentAppState = excalidrawAPI.getAppState()
@@ -204,6 +238,7 @@ export function useCollaboration() {
 				excalidrawAPI.updateScene({
 					elements: payload.elements,
 					appState: mergedAppState,
+					captureUpdate: CaptureUpdateAction.NEVER,
 				})
 
 				const filesArray = Object.values(payload.files || {}).filter(
@@ -217,7 +252,7 @@ export function useCollaboration() {
 				console.error('[Collaboration] Error applying restored scene:', error)
 			}
 		},
-		[excalidrawAPI],
+		[excalidrawAPI, replaceBroadcastedElementVersions],
 	)
 
 	useEffect(() => {
@@ -231,10 +266,11 @@ export function useCollaboration() {
 			applySceneReplacement(payload)
 		}
 
-		if (pendingSceneUpdateRef.current) {
-			const latestScene = pendingSceneUpdateRef.current
-			pendingSceneUpdateRef.current = null
-			reconcileAndApplyRemoteElements(latestScene)
+		if (pendingSceneUpdatesRef.current.length > 0) {
+			const [queuedScene] = pendingSceneUpdatesRef.current.splice(0)
+			if (queuedScene) {
+				reconcileAndApplyRemoteElements(queuedScene)
+			}
 		}
 
 		if (pendingImageUpdatesRef.current.size > 0) {
@@ -247,10 +283,11 @@ export function useCollaboration() {
 	}, [excalidrawAPI, handleRemoteImageAdd, reconcileAndApplyRemoteElements, applySceneReplacement])
 
 	useEffect(() => {
-		pendingSceneUpdateRef.current = null
+		pendingSceneUpdatesRef.current = []
 		pendingImageUpdatesRef.current.clear()
 		pendingSceneReplaceRef.current = null
-	}, [fileId])
+		resetSceneSyncState()
+	}, [fileId, resetSceneSyncState])
 
 	// --- Collaborator State Management ---
 	const updateCollaboratorsState = useCallback(
@@ -516,7 +553,56 @@ export function useCollaboration() {
 		debouncedJoinRoom(currentSocket, roomIdStr)
 	}, [fileId, debouncedJoinRoom]) // Dependencies read via store state
 
-	let lastElementsString = null
+	const sendSceneBootstrapToSocket = useCallback((targetSocketId: string) => {
+		const currentExcalidrawAPI = useExcalidrawStore.getState().excalidrawAPI
+		const currentFileId = useWhiteboardConfigStore.getState().fileId
+		const { isDedicatedSyncer, socket } = useCollaborationStore.getState()
+		if (!isDedicatedSyncer || !socket || !socket.connected || !currentFileId || !currentExcalidrawAPI) {
+			return
+		}
+
+		if (socket.id === targetSocketId) {
+			return
+		}
+
+		console.log(`[Collaboration] Sending targeted scene bootstrap to socket: ${targetSocketId}`)
+		const sceneElements = currentExcalidrawAPI.getSceneElementsIncludingDeleted()
+		const sceneData = {
+			type: BroadcastType.SceneInit,
+			payload: {
+				elements: sceneElements,
+			},
+		}
+		const sceneBuffer = new TextEncoder().encode(JSON.stringify(sceneData))
+		socket.emit('server-direct-broadcast', `${currentFileId}`, targetSocketId, sceneBuffer, [])
+
+		const files = currentExcalidrawAPI.getFiles()
+		Object.entries(files).forEach(([, file]) => {
+			if (!file?.dataURL) {
+				return
+			}
+
+			const fileData = { type: BroadcastType.ImageAdd, payload: { file } }
+			const fileBuffer = new TextEncoder().encode(JSON.stringify(fileData))
+			socket.emit('server-direct-broadcast', `${currentFileId}`, targetSocketId, fileBuffer, [])
+		})
+	}, [])
+
+	const requestSceneBootstrap = useCallback((targetSocketId: string) => {
+		const socket = useCollaborationStore.getState().socket
+		if (!socket || !socket.connected || !fileId) {
+			return
+		}
+
+		const requestData = {
+			type: BroadcastType.SceneInitRequest,
+			payload: {
+				socketId: targetSocketId,
+			},
+		}
+		const requestBuffer = new TextEncoder().encode(JSON.stringify(requestData))
+		socket.emit('server-broadcast', `${fileId}`, requestBuffer, [])
+	}, [fileId])
 
 	const handleClientBroadcast = useCallback(
 		async (data: ArrayBuffer) => {
@@ -549,7 +635,7 @@ export function useCollaboration() {
 						const scrollToContent = payload.scrollToContent ?? true
 
 						// Clear pending queue state since we have an authoritative snapshot
-						pendingSceneUpdateRef.current = null
+						pendingSceneUpdatesRef.current = []
 						pendingImageUpdatesRef.current.clear()
 
 						if (excalidrawAPI) {
@@ -591,16 +677,18 @@ export function useCollaboration() {
 					break
 				}
 				case BroadcastType.SceneInit:
+				case BroadcastType.SceneUpdate:
 					if (Array.isArray(decoded.payload?.elements)) {
-						const elementsString = JSON.stringify(decoded.payload.elements)
-						if (elementsString === lastElementsString) {
-							console.warn('[Collaboration] Received identical SceneInit payload, skipping update')
-							break
-						}
 						queueSceneUpdate(decoded.payload.elements)
-						lastElementsString = JSON.stringify(decoded.payload.elements)
 					} else {
-						console.warn('[Collaboration] Invalid SceneInit payload:', decoded.payload)
+						console.warn('[Collaboration] Invalid scene payload:', decoded.payload)
+					}
+					break
+				case BroadcastType.SceneInitRequest:
+					if (typeof decoded.payload?.socketId === 'string') {
+						sendSceneBootstrapToSocket(decoded.payload.socketId)
+					} else {
+						console.warn('[Collaboration] Invalid scene bootstrap request payload:', decoded.payload)
 					}
 					break
 				case BroadcastType.MouseLocation:
@@ -654,7 +742,7 @@ export function useCollaboration() {
 				console.error('[Collaboration] Error processing client broadcast:', error)
 			}
 		},
-		[queueSceneUpdate, updateCursorState, queueImageUpdate, updateViewportState, excalidrawAPI, fileId, applySceneReplacement],
+		[queueSceneUpdate, sendSceneBootstrapToSocket, updateCursorState, queueImageUpdate, updateViewportState, excalidrawAPI, fileId, applySceneReplacement],
 	)
 
 	const handleSyncDesignate = useCallback((data: { isSyncer: boolean }) => {
@@ -662,29 +750,15 @@ export function useCollaboration() {
 		setDedicatedSyncer(data.isSyncer)
 	}, [setDedicatedSyncer])
 
-	// Handle user joined event - broadcast all images if we're the syncer
-	const handleUserJoined = useCallback((data: { userId: string, userName: string, socketId: string, isSyncer: boolean }) => {
-		// If we are the syncer, broadcast all our images to the new user
-		const { isDedicatedSyncer } = useCollaborationStore.getState()
-		if (isDedicatedSyncer && excalidrawAPI) {
-			console.log(`[Collaboration] Broadcasting images to new user: ${data.userName}`)
-
-			const files = excalidrawAPI.getFiles()
-			const socket = useCollaborationStore.getState().socket
-
-			if (!socket || !socket.connected || !fileId) return
-
-			// Broadcast each image file
-			Object.entries(files).forEach(([, file]) => {
-				if (file && file.dataURL) {
-					const fileData = { type: BroadcastType.ImageAdd, payload: { file } }
-					const fileJson = JSON.stringify(fileData)
-					const fileBuffer = new TextEncoder().encode(fileJson)
-					socket.emit('server-broadcast', `${fileId}`, fileBuffer, [])
-				}
-			})
+	const handleUserJoined = useCallback((data: { socketId: string }) => {
+		const socket = useCollaborationStore.getState().socket
+		if (!socket || !socket.connected || !fileId || socket.id !== data.socketId) {
+			return
 		}
-	}, [excalidrawAPI, fileId])
+
+		console.log(`[Collaboration] Requesting targeted scene bootstrap for socket: ${data.socketId}`)
+		requestSceneBootstrap(data.socketId)
+	}, [fileId, requestSceneBootstrap])
 
 	// No custom reconnection strategy needed - socket.io will handle reconnection with Infinity attempts
 
@@ -712,7 +786,7 @@ export function useCollaboration() {
 
 					// Stop auto reconnection attempts on auth error and try token refresh
 					socketInstance.disconnect()
-					await handleTokenRefresh()
+					await handleTokenRefreshRef.current()
 				} else {
 					setStatus('offline')
 				}
@@ -745,7 +819,7 @@ export function useCollaboration() {
 
 			socketInstance.on('disconnect', (reason) => {
 				console.warn(`[Collaboration] Socket disconnect event fired: ${reason}`)
-				clearExcalidrawCollaborators()
+				clearExcalidrawCollaboratorsRef.current()
 				setIsInRoom(false)
 
 				// Only set to offline if this is an intentional disconnect
@@ -826,32 +900,40 @@ export function useCollaboration() {
 
 				// This is the primary trigger for joining a room - the server sends this event
 				// when a socket connects, and we respond by joining the appropriate room
-				handleInitRoom()
+				handleInitRoomRef.current()
 			})
 
 			socketInstance.on('room-user-change', (data) => {
 				console.log(`[Collaboration] Room user change: ${data.length} users`)
 				setIsInRoom(true)
-				updateCollaboratorsState(data)
+				updateCollaboratorsStateRef.current(data)
 			})
 
-			socketInstance.on('client-broadcast', handleClientBroadcast)
-			socketInstance.on('sync-designate', handleSyncDesignate)
+			socketInstance.on('client-broadcast', (data) => {
+				handleClientBroadcastRef.current(data).catch((error) => {
+					console.error('[Collaboration] Error processing client broadcast:', error)
+				})
+			})
+			socketInstance.on('sync-designate', (data) => {
+				handleSyncDesignateRef.current(data)
+			})
 
 			socketInstance.on('user-joined', (data) => {
 				console.log(`[Collaboration] User joined: ${data.userName} (${data.userId})`)
-				handleUserJoined(data)
+				handleUserJoinedRef.current(data)
 			})
 
 			// Handle request for presenter's viewport
 			socketInstance.on('request-presenter-viewport', async () => {
 				console.log('[Collaboration] Presenter viewport requested')
+				const currentExcalidrawAPI = excalidrawAPIRef.current
+				const currentFileId = fileIdRef.current
 
 				// Check if we're the presenter
 				const { isPresenting } = useCollaborationStore.getState()
 
-				if (isPresenting && excalidrawAPI) {
-					const appState = excalidrawAPI.getAppState()
+				if (isPresenting && currentExcalidrawAPI && currentFileId) {
+					const appState = currentExcalidrawAPI.getAppState()
 					const { presenterId } = useCollaborationStore.getState()
 
 					const viewportData = {
@@ -867,7 +949,7 @@ export function useCollaboration() {
 					// Broadcast viewport to all users
 					const viewportJson = JSON.stringify(viewportData)
 					const viewportBuffer = new TextEncoder().encode(viewportJson)
-					socketInstance.emit('server-broadcast', `${fileId}`, viewportBuffer, [])
+					socketInstance.emit('server-broadcast', `${currentFileId}`, viewportBuffer, [])
 
 					console.log('[Collaboration] Sent presenter viewport:', viewportData.payload)
 				}
@@ -877,10 +959,12 @@ export function useCollaboration() {
 			socketInstance.on('send-viewport-request', async (data) => {
 				const { requesterId } = data
 				console.log(`[Collaboration] Viewport requested by user ${requesterId}`)
+				const currentExcalidrawAPI = excalidrawAPIRef.current
+				const currentFileId = fileIdRef.current
 
 				// Send our current viewport back to the requester
-				if (excalidrawAPI) {
-					const appState = excalidrawAPI.getAppState()
+				if (currentExcalidrawAPI && currentFileId) {
+					const appState = currentExcalidrawAPI.getAppState()
 
 					// Check if we're the presenter
 					const { isPresenting, presenterId: currentPresenterId } = useCollaborationStore.getState()
@@ -892,7 +976,7 @@ export function useCollaboration() {
 						userId = currentPresenterId
 					} else {
 						// Otherwise get our actual user ID from JWT
-						const jwt = await getJWT()
+						const jwt = await getJWTRef.current()
 						if (jwt) {
 							try {
 								const payload = JSON.parse(atob(jwt.split('.')[1]))
@@ -916,7 +1000,7 @@ export function useCollaboration() {
 					// Send directly to the requester via server broadcast
 					const viewportJson = JSON.stringify(viewportData)
 					const viewportBuffer = new TextEncoder().encode(viewportJson)
-					socketInstance.emit('server-broadcast', `${fileId}`, viewportBuffer, [])
+					socketInstance.emit('server-broadcast', `${currentFileId}`, viewportBuffer, [])
 
 					console.log('[Collaboration] Sent viewport to requester:', viewportData.payload)
 				}
@@ -942,6 +1026,20 @@ export function useCollaboration() {
 	// --- Socket Connection Logic ---
 	const connectSocketRef = useRef(() => Promise.resolve())
 	const socketInstanceRef = useRef<CollaborationSocket | null>(null)
+	const disconnectSocketRef = useRef<DisconnectCallback>(function noop() {})
+	const resetStoreRef = useRef(resetStore)
+	const debouncedJoinRoomRef = useRef(debouncedJoinRoom)
+	const throttledUpdateCursorRef = useRef(throttledUpdateCursor)
+	const handleTokenRefreshRef = useRef(handleTokenRefresh)
+	const handleInitRoomRef = useRef(handleInitRoom)
+	const updateCollaboratorsStateRef = useRef(updateCollaboratorsState)
+	const handleClientBroadcastRef = useRef(handleClientBroadcast)
+	const handleSyncDesignateRef = useRef(handleSyncDesignate)
+	const clearExcalidrawCollaboratorsRef = useRef(clearExcalidrawCollaborators)
+	const handleUserJoinedRef = useRef(handleUserJoined)
+	const excalidrawAPIRef = useRef(excalidrawAPI)
+	const fileIdRef = useRef(fileId)
+	const getJWTRef = useRef(getJWT)
 
 	const connectSocket = useCallback(async () => {
 		// Use the fileId from our selective subscription instead of getState
@@ -1079,24 +1177,82 @@ export function useCollaboration() {
 		socketInstanceRef.current = null
 	}, [setSocket, setStatus, clearExcalidrawCollaborators])
 
+	useEffect(() => {
+		disconnectSocketRef.current = disconnectSocket
+	}, [disconnectSocket])
+
+	useEffect(() => {
+		resetStoreRef.current = resetStore
+	}, [resetStore])
+
+	useEffect(() => {
+		debouncedJoinRoomRef.current = debouncedJoinRoom
+	}, [debouncedJoinRoom])
+
+	useEffect(() => {
+		throttledUpdateCursorRef.current = throttledUpdateCursor
+	}, [throttledUpdateCursor])
+
+	useEffect(() => {
+		handleTokenRefreshRef.current = handleTokenRefresh
+	}, [handleTokenRefresh])
+
+	useEffect(() => {
+		handleInitRoomRef.current = handleInitRoom
+	}, [handleInitRoom])
+
+	useEffect(() => {
+		updateCollaboratorsStateRef.current = updateCollaboratorsState
+	}, [updateCollaboratorsState])
+
+	useEffect(() => {
+		handleClientBroadcastRef.current = handleClientBroadcast
+	}, [handleClientBroadcast])
+
+	useEffect(() => {
+		handleSyncDesignateRef.current = handleSyncDesignate
+	}, [handleSyncDesignate])
+
+	useEffect(() => {
+		clearExcalidrawCollaboratorsRef.current = clearExcalidrawCollaborators
+	}, [clearExcalidrawCollaborators])
+
+	useEffect(() => {
+		handleUserJoinedRef.current = handleUserJoined
+	}, [handleUserJoined])
+
+	useEffect(() => {
+		excalidrawAPIRef.current = excalidrawAPI
+	}, [excalidrawAPI])
+
+	useEffect(() => {
+		fileIdRef.current = fileId
+	}, [fileId])
+
+	useEffect(() => {
+		getJWTRef.current = getJWT
+	}, [getJWT])
+
 	// --- Effects ---
 	// Connect/Disconnect based on fileId
 	useEffect(() => {
 		if (fileId) {
 			console.log(`[Collaboration] FileId ${fileId} active, connecting socket`)
-			connectSocket()
+			connectSocketRef.current().catch((error) => {
+				console.error('[Collaboration] Connection effect failed:', error)
+			})
 		} else {
 			console.log('[Collaboration] No fileId, disconnecting socket')
-			disconnectSocket()
+			disconnectSocketRef.current()
 			setIsInRoom(false)
 		}
 
 		// Cleanup when fileId changes
 		return () => {
 			// Cancel any pending debounced room joins
-			debouncedJoinRoom.cancel()
+			debouncedJoinRoomRef.current.cancel()
 		}
-	}, [fileId, connectSocket, disconnectSocket, debouncedJoinRoom])
+	}, [fileId, setIsInRoom])
 
 	// Cleanup on unmount
 	useEffect(() => {
@@ -1104,16 +1260,16 @@ export function useCollaboration() {
 			console.log('[Collaboration] Unmounting, performing full cleanup')
 
 			// Cancel any pending operations
-			debouncedJoinRoom.cancel()
-			throttledUpdateCursor.cancel()
+			debouncedJoinRoomRef.current.cancel()
+			throttledUpdateCursorRef.current.cancel()
 
 			// Disconnect socket
-			disconnectSocket()
+			disconnectSocketRef.current()
 
 			// Reset store state
-			resetStore()
+			resetStoreRef.current()
 		}
-	}, [disconnectSocket, resetStore, throttledUpdateCursor, debouncedJoinRoom])
+	}, [])
 
 	// --- Exported Hook API ---
 	return {

--- a/src/hooks/useComment.tsx
+++ b/src/hooks/useComment.tsx
@@ -8,12 +8,13 @@ import { createRoot } from 'react-dom/client'
 import { mdiCommentOutline, mdiAccount } from '@mdi/js'
 import { useExcalidrawStore } from '../stores/useExcalidrawStore'
 import { useShallow } from 'zustand/react/shallow'
-import { viewportCoordsToSceneCoords, convertToExcalidrawElements } from '@nextcloud/excalidraw'
+import { viewportCoordsToSceneCoords, convertToExcalidrawElements, newElementWith } from '@nextcloud/excalidraw'
 import { generateUrl } from '@nextcloud/router'
 import { getCurrentUser } from '@nextcloud/auth'
 import { CommentPopover } from '../components/CommentPopover'
 import { renderToolbarButton } from '../components/ToolbarButton'
 import { getRelativeTime } from '../utils/time'
+import { updateElementCustomData } from '../utils/updateElementCustomData'
 import './useComment.scss'
 import { t } from '@nextcloud/l10n'
 
@@ -329,10 +330,16 @@ export function useComment(props?: UseCommentProps) {
 		const elements = excalidrawAPI.getSceneElementsIncludingDeleted()
 		const updatedElements = elements.map((el: unknown) => {
 			if (isCommentElement(el) && el.customData?.commentThread?.id === threadId) {
-				return {
-					...el,
-					...updater(el.customData.commentThread),
+				const patch = updater(el.customData.commentThread)
+
+				if (patch.customData && typeof patch.customData === 'object') {
+					return updateElementCustomData(el, (customData) => ({
+						...customData,
+						...(patch.customData as Record<string, unknown>),
+					}))
 				}
+
+				return newElementWith(el, patch)
 			}
 			return el
 		})

--- a/src/hooks/useSync.ts
+++ b/src/hooks/useSync.ts
@@ -44,6 +44,28 @@ type SceneSnapshot = {
 	appState: Partial<AppState>
 }
 
+declare global {
+	interface Window {
+		__whiteboardTest?: boolean
+		__whiteboardTestHooks?: Record<string, unknown> & {
+			syncDebugState?: Record<string, unknown>
+		}
+	}
+}
+
+const publishSyncDebugState = (partialState: Record<string, unknown>) => {
+	if (typeof window === 'undefined' || !window.__whiteboardTest) {
+		return
+	}
+
+	window.__whiteboardTestHooks = window.__whiteboardTestHooks || {}
+	const currentState = (window.__whiteboardTestHooks.syncDebugState as Record<string, unknown> | undefined) || {}
+	window.__whiteboardTestHooks.syncDebugState = {
+		...currentState,
+		...partialState,
+	}
+}
+
 export function useSync() {
 	const { fileId, isReadOnly } = useWhiteboardConfigStore(
 		useShallow(state => ({
@@ -116,6 +138,11 @@ export function useSync() {
 			appState: snapshotAppState,
 		}
 
+		publishSyncDebugState({
+			latestElementsCount: snapshotElements.length,
+			latestFileCount: Object.keys(snapshotFiles || {}).length,
+		})
+
 		return latestSnapshotRef.current
 	}, [excalidrawAPI])
 
@@ -135,6 +162,11 @@ export function useSync() {
 		pendingLocalSyncRef.current = false
 		pendingServerSyncRef.current = false
 		pendingWebSocketSyncRef.current = false
+		publishSyncDebugState({
+			pendingLocalSync: false,
+			pendingServerSync: false,
+			pendingWebSocketSync: false,
+		})
 		useCollaborationStore.getState().resetSceneSyncState()
 	}, [fileId])
 
@@ -147,6 +179,15 @@ export function useSync() {
 
 	const doSyncToLocal = useCallback(async () => {
 		if (!isWorkerReady || !worker || !fileId || !excalidrawAPI || isReadOnly) {
+			publishSyncDebugState({
+				lastLocalSyncSkip: {
+					isWorkerReady,
+					hasWorker: Boolean(worker),
+					fileId,
+					hasExcalidrawAPI: Boolean(excalidrawAPI),
+					isReadOnly,
+				},
+			})
 			return
 		}
 
@@ -165,6 +206,10 @@ export function useSync() {
 			}
 			worker.postMessage(message)
 			pendingLocalSyncRef.current = false
+			publishSyncDebugState({
+				lastLocalSyncPostedAt: Date.now(),
+				pendingLocalSync: false,
+			})
 			logSyncResult('local', { status: 'syncing' })
 		} catch (error) {
 			logger.error('[Sync] Local sync failed:', error)
@@ -174,10 +219,27 @@ export function useSync() {
 
 	const doSyncToServerAPI = useCallback(async (forceSync = false) => {
 		logger.debug('[Sync] doSyncToServerAPI called', { forceSync, isDedicatedSyncer, collabStatus })
+		publishSyncDebugState({
+			lastServerSyncAttemptAt: Date.now(),
+			lastServerSyncForce: forceSync,
+			lastServerSyncGate: {
+				isWorkerReady,
+				hasWorker: Boolean(worker),
+				fileId,
+				hasExcalidrawAPI: Boolean(excalidrawAPI),
+				isDedicatedSyncer,
+				isReadOnly,
+				collabStatus,
+			},
+		})
 
 		if (!forceSync && (!isWorkerReady || !worker || !fileId || !excalidrawAPI || !isDedicatedSyncer || isReadOnly || collabStatus !== 'online')) {
 			logger.debug('[Sync] Skipping server sync - normal conditions not met', {
 				isWorkerReady, worker: !!worker, fileId, excalidrawAPI: !!excalidrawAPI, isDedicatedSyncer, isReadOnly, collabStatus,
+			})
+			publishSyncDebugState({
+				lastServerSyncSkippedAt: Date.now(),
+				lastServerSyncSkipReason: 'normal-conditions-not-met',
 			})
 			return
 		}
@@ -185,6 +247,10 @@ export function useSync() {
 		if (forceSync && (!isWorkerReady || !worker || !fileId || !excalidrawAPI || isReadOnly)) {
 			logger.debug('[Sync] Skipping forced server sync - minimum requirements not met', {
 				isWorkerReady, worker: !!worker, fileId, excalidrawAPI: !!excalidrawAPI, isReadOnly,
+			})
+			publishSyncDebugState({
+				lastServerSyncSkippedAt: Date.now(),
+				lastServerSyncSkipReason: 'forced-minimum-requirements-not-met',
 			})
 			return
 		}
@@ -215,14 +281,30 @@ export function useSync() {
 			worker.postMessage(message)
 			logger.debug('[Sync] SYNC_TO_SERVER message sent to worker')
 			pendingServerSyncRef.current = false
+			publishSyncDebugState({
+				lastServerSyncPostedAt: Date.now(),
+				pendingServerSync: false,
+			})
 		} catch (error) {
 			logger.error('[Sync] Server API sync failed:', error)
+			publishSyncDebugState({
+				lastServerSyncErrorAt: Date.now(),
+				lastServerSyncError: error instanceof Error ? error.message : String(error),
+			})
 			logSyncResult('server', { status: 'error API', error: error instanceof Error ? error.message : String(error) })
 		}
 	}, [isWorkerReady, worker, fileId, excalidrawAPI, isDedicatedSyncer, isReadOnly, collabStatus, getJWT, getLatestSnapshot])
 
 	const doSyncViaWebSocket = useCallback(async () => {
 		if (!fileId || !socket || collabStatus !== 'online' || isReadOnly) {
+			publishSyncDebugState({
+				lastWebSocketSyncSkip: {
+					fileId,
+					hasSocket: Boolean(socket),
+					collabStatus,
+					isReadOnly,
+				},
+			})
 			return
 		}
 
@@ -281,6 +363,10 @@ export function useSync() {
 			}
 
 			pendingWebSocketSyncRef.current = false
+			publishSyncDebugState({
+				lastWebSocketSyncPostedAt: Date.now(),
+				pendingWebSocketSync: false,
+			})
 			logSyncResult('websocket', { status: 'sync success', elementsCount: syncedElementsCount })
 		} catch (error) {
 			logger.error('[Sync] WebSocket sync failed:', error)
@@ -306,10 +392,12 @@ export function useSync() {
 
 	useEffect(() => {
 		if (pendingLocalSyncRef.current && isWorkerReady && worker && fileId && excalidrawAPI && !isReadOnly) {
+			publishSyncDebugState({ lastLocalSyncRescheduledAt: Date.now() })
 			throttledSyncToLocal()
 		}
 
 		if (pendingWebSocketSyncRef.current && fileId && socket && collabStatus === 'online' && !isReadOnly) {
+			publishSyncDebugState({ lastWebSocketSyncRescheduledAt: Date.now() })
 			throttledSyncViaWebSocket()
 		}
 
@@ -323,6 +411,7 @@ export function useSync() {
 			&& !isReadOnly
 			&& collabStatus === 'online'
 		) {
+			publishSyncDebugState({ lastServerSyncRescheduledAt: Date.now() })
 			throttledSyncToServerAPI()
 		}
 	}, [
@@ -427,6 +516,12 @@ export function useSync() {
 		pendingLocalSyncRef.current = true
 		pendingServerSyncRef.current = true
 		pendingWebSocketSyncRef.current = true
+		publishSyncDebugState({
+			lastOnChangeAt: Date.now(),
+			pendingLocalSync: true,
+			pendingServerSync: true,
+			pendingWebSocketSync: true,
+		})
 
 		const snapshot = captureSnapshot(elements, appState, files)
 		if (snapshot) {

--- a/src/hooks/useSync.ts
+++ b/src/hooks/useSync.ts
@@ -5,22 +5,27 @@
 
 import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { throttle } from 'lodash'
+import { hashString } from '@nextcloud/excalidraw'
+import type { ExcalidrawElement } from '@nextcloud/excalidraw/dist/types/excalidraw/element/types'
+import type { AppState, BinaryFiles } from '@nextcloud/excalidraw/dist/types/excalidraw/types'
+import { generateUrl } from '@nextcloud/router'
+import { useShallow } from 'zustand/react/shallow'
 import { useWhiteboardConfigStore } from '../stores/useWhiteboardConfigStore'
 import { useSyncStore, logSyncResult } from '../stores/useSyncStore'
 import { useExcalidrawStore } from '../stores/useExcalidrawStore'
 import { useJWTStore } from '../stores/useJwtStore'
 import { useCollaborationStore } from '../stores/useCollaborationStore'
-import { generateUrl } from '@nextcloud/router'
-import { useShallow } from 'zustand/react/shallow'
 import logger from '../utils/logger'
 import { sanitizeAppStateForSync } from '../utils/sanitizeAppState'
-import type { ExcalidrawElement } from '@excalidraw/excalidraw/types/element/types'
-import type { BinaryFiles } from '@excalidraw/excalidraw/types/types'
 import type { CollaborationSocket } from '../types/collaboration'
 import type { WorkerInboundMessage } from '../types/protocol'
+import {
+	buildBroadcastedElementVersions,
+	planIncrementalSceneSync,
+} from '../utils/syncSceneData'
 
 enum SyncMessageType {
-	SceneInit = 'SCENE_INIT',
+	SceneUpdate = 'SCENE_UPDATE',
 	ImageAdd = 'IMAGE_ADD',
 	MouseLocation = 'MOUSE_LOCATION',
 	ViewportUpdate = 'VIEWPORT_UPDATE',
@@ -32,6 +37,12 @@ const LOCAL_SYNC_DELAY = 1000
 const SERVER_API_SYNC_DELAY = 10000
 const WEBSOCKET_SYNC_DELAY = 500
 const CURSOR_SYNC_DELAY = 50
+
+type SceneSnapshot = {
+	elements: readonly ExcalidrawElement[]
+	files: BinaryFiles
+	appState: Partial<AppState>
+}
 
 export function useSync() {
 	const { fileId, isReadOnly } = useWhiteboardConfigStore(
@@ -75,7 +86,43 @@ export function useSync() {
 		})),
 	)
 
-	// --- Worker Initialization ---
+	const latestSnapshotRef = useRef<SceneSnapshot>({
+		elements: [],
+		files: {} as BinaryFiles,
+		appState: {},
+	})
+	const prevSyncedFilesRef = useRef<Record<string, number>>({})
+	const isSyncerRef = useRef(isDedicatedSyncer)
+	const pendingLocalSyncRef = useRef(false)
+	const pendingServerSyncRef = useRef(false)
+	const pendingWebSocketSyncRef = useRef(false)
+
+	const captureSnapshot = useCallback((
+		elements?: readonly ExcalidrawElement[],
+		appState?: AppState,
+		files?: BinaryFiles,
+	): SceneSnapshot | null => {
+		if (!excalidrawAPI) {
+			return null
+		}
+
+		const snapshotElements = elements ?? excalidrawAPI.getSceneElementsIncludingDeleted()
+		const snapshotAppState = sanitizeAppStateForSync(appState ?? excalidrawAPI.getAppState())
+		const snapshotFiles = (files ?? excalidrawAPI.getFiles()) as BinaryFiles
+
+		latestSnapshotRef.current = {
+			elements: snapshotElements,
+			files: snapshotFiles,
+			appState: snapshotAppState,
+		}
+
+		return latestSnapshotRef.current
+	}, [excalidrawAPI])
+
+	const getLatestSnapshot = useCallback(() => {
+		return captureSnapshot() ?? latestSnapshotRef.current
+	}, [captureSnapshot])
+
 	useEffect(() => {
 		initializeWorker()
 		return () => {
@@ -83,42 +130,51 @@ export function useSync() {
 		}
 	}, [initializeWorker, terminateWorker])
 
-	// Keep track of previously synced files to avoid resending unchanged files
-	const prevSyncedFilesRef = useRef<Record<string, string>>({})
-
-	// Reset prevSyncedFilesRef when fileId changes to prevent leakage across files
 	useEffect(() => {
 		prevSyncedFilesRef.current = {}
-	}, [fileId]) // Depends on fileId from the hook scope
+		pendingLocalSyncRef.current = false
+		pendingServerSyncRef.current = false
+		pendingWebSocketSyncRef.current = false
+		useCollaborationStore.getState().resetSceneSyncState()
+	}, [fileId])
 
-	// --- Sync Logic ---
+	useEffect(() => {
+		if (isDedicatedSyncer !== isSyncerRef.current) {
+			logger.debug('[Sync] SYNCER STATUS:', isDedicatedSyncer ? 'DESIGNATED AS SYNCER' : 'NOT SYNCER')
+			isSyncerRef.current = isDedicatedSyncer
+		}
+	}, [isDedicatedSyncer])
 
-	// Saves current state to IndexedDB
 	const doSyncToLocal = useCallback(async () => {
 		if (!isWorkerReady || !worker || !fileId || !excalidrawAPI || isReadOnly) {
 			return
 		}
 
 		try {
-			const elements = excalidrawAPI.getSceneElementsIncludingDeleted() as readonly ExcalidrawElement[]
-			const appState = excalidrawAPI.getAppState()
-			const files = excalidrawAPI.getFiles() as BinaryFiles
-			const filteredAppState = sanitizeAppStateForSync(appState)
+			const snapshot = getLatestSnapshot()
+			if (!snapshot) {
+				return
+			}
 
-			const message: WorkerInboundMessage = { type: 'SYNC_TO_LOCAL', fileId, elements, files, appState: filteredAppState }
+			const message: WorkerInboundMessage = {
+				type: 'SYNC_TO_LOCAL',
+				fileId,
+				elements: snapshot.elements,
+				files: snapshot.files,
+				appState: snapshot.appState,
+			}
 			worker.postMessage(message)
+			pendingLocalSyncRef.current = false
 			logSyncResult('local', { status: 'syncing' })
 		} catch (error) {
 			logger.error('[Sync] Local sync failed:', error)
 			logSyncResult('local', { status: 'error', error: error instanceof Error ? error.message : String(error) })
 		}
-	}, [isWorkerReady, worker, fileId, excalidrawAPI, isReadOnly])
+	}, [isWorkerReady, worker, fileId, excalidrawAPI, isReadOnly, getLatestSnapshot])
 
-	// Saves current state to the Nextcloud server API
 	const doSyncToServerAPI = useCallback(async (forceSync = false) => {
 		logger.debug('[Sync] doSyncToServerAPI called', { forceSync, isDedicatedSyncer, collabStatus })
 
-		// Allow force sync for final save, otherwise check normal conditions
 		if (!forceSync && (!isWorkerReady || !worker || !fileId || !excalidrawAPI || !isDedicatedSyncer || isReadOnly || collabStatus !== 'online')) {
 			logger.debug('[Sync] Skipping server sync - normal conditions not met', {
 				isWorkerReady, worker: !!worker, fileId, excalidrawAPI: !!excalidrawAPI, isDedicatedSyncer, isReadOnly, collabStatus,
@@ -126,7 +182,6 @@ export function useSync() {
 			return
 		}
 
-		// For force sync, only check minimum requirements
 		if (forceSync && (!isWorkerReady || !worker || !fileId || !excalidrawAPI || isReadOnly)) {
 			logger.debug('[Sync] Skipping forced server sync - minimum requirements not met', {
 				isWorkerReady, worker: !!worker, fileId, excalidrawAPI: !!excalidrawAPI, isReadOnly,
@@ -135,7 +190,6 @@ export function useSync() {
 		}
 
 		logSyncResult('server', { status: 'syncing API' })
-		logger.debug('[Sync] Sending SYNC_TO_SERVER message to worker')
 
 		try {
 			const jwt = await getJWT()
@@ -144,94 +198,147 @@ export function useSync() {
 				throw new Error('FileId changed during server sync preparation.')
 			}
 
-			const elements = excalidrawAPI.getSceneElementsIncludingDeleted() as readonly ExcalidrawElement[]
-			const files = excalidrawAPI.getFiles() as BinaryFiles
+			const snapshot = getLatestSnapshot()
+			if (!snapshot) {
+				return
+			}
 
 			const message: WorkerInboundMessage = {
 				type: 'SYNC_TO_SERVER',
 				fileId,
 				url: generateUrl(`apps/whiteboard/${fileId}`),
 				jwt,
-				elements,
-				files,
+				elements: snapshot.elements,
+				files: snapshot.files,
 			}
 
 			worker.postMessage(message)
 			logger.debug('[Sync] SYNC_TO_SERVER message sent to worker')
+			pendingServerSyncRef.current = false
 		} catch (error) {
 			logger.error('[Sync] Server API sync failed:', error)
 			logSyncResult('server', { status: 'error API', error: error instanceof Error ? error.message : String(error) })
 		}
-	}, [isWorkerReady, worker, fileId, excalidrawAPI, isDedicatedSyncer, isReadOnly, collabStatus, getJWT])
+	}, [isWorkerReady, worker, fileId, excalidrawAPI, isDedicatedSyncer, isReadOnly, collabStatus, getJWT, getLatestSnapshot])
 
-	// Simple hash function for file content
-	const hashFileContent = (content: string): string => {
-		if (!content) return ''
-		const len = content.length
-		const start = content.substring(0, 20)
-		const end = content.substring(Math.max(0, len - 20))
-		return `${len}:${start}:${end}`
-	}
-
-	// Syncs scene and files via WebSocket
 	const doSyncViaWebSocket = useCallback(async () => {
-		if (!fileId || !excalidrawAPI || !socket || collabStatus !== 'online' || isReadOnly) {
+		if (!fileId || !socket || collabStatus !== 'online' || isReadOnly) {
 			return
 		}
 
 		try {
-			const elements = excalidrawAPI.getSceneElementsIncludingDeleted() as readonly ExcalidrawElement[]
-			const files = excalidrawAPI.getFiles() as BinaryFiles
+			const snapshot = getLatestSnapshot()
+			if (!snapshot) {
+				return
+			}
 
-			// 1. Send Scene
-			const sceneData = { type: SyncMessageType.SceneInit, payload: { elements } }
-			const sceneJson = JSON.stringify(sceneData)
-			const sceneBuffer = new TextEncoder().encode(sceneJson)
-			socket.emit(SyncMessageType.ServerBroadcast, `${fileId}`, sceneBuffer, [])
+			const { elements, files } = snapshot
+			const sceneSyncPlan = planIncrementalSceneSync({
+				elements,
+				broadcastedElementVersions: useCollaborationStore.getState().broadcastedElementVersions,
+				lastSceneHash: useCollaborationStore.getState().lastSceneHash,
+			})
+			let syncedElementsCount = 0
 
-			// 2. Send only new or changed files
+			if (sceneSyncPlan.type === 'broadcast') {
+				const sceneData = {
+					type: SyncMessageType.SceneUpdate,
+					payload: {
+						elements: sceneSyncPlan.sceneElements,
+					},
+				}
+				const sceneBuffer = new TextEncoder().encode(JSON.stringify(sceneData))
+				socket.emit(SyncMessageType.ServerBroadcast, `${fileId}`, sceneBuffer, [])
+
+				useCollaborationStore.getState().replaceBroadcastedElementVersions(
+					buildBroadcastedElementVersions(elements),
+				)
+				useCollaborationStore.getState().setLastSceneHash(sceneSyncPlan.sceneHash)
+				syncedElementsCount = sceneSyncPlan.sceneElements.length
+			} else if (sceneSyncPlan.type === 'advance') {
+				useCollaborationStore.getState().replaceBroadcastedElementVersions(
+					sceneSyncPlan.broadcastedElementVersions,
+				)
+				useCollaborationStore.getState().setLastSceneHash(sceneSyncPlan.sceneHash)
+			}
+
 			if (files && Object.keys(files).length > 0) {
-				const currentFileHashes: Record<string, string> = {}
+				const currentFileHashes: Record<string, number> = {}
 				for (const fileIdKey in files) {
 					const file = files[fileIdKey]
 					if (!file?.dataURL) continue
-					const currentHash = hashFileContent(file.dataURL)
+					const currentHash = hashString(file.dataURL)
 					currentFileHashes[fileIdKey] = currentHash
 					if (prevSyncedFilesRef.current[fileIdKey] !== currentHash) {
 						const fileData = { type: SyncMessageType.ImageAdd, payload: { file } }
-						const fileJson = JSON.stringify(fileData)
-						const fileBuffer = new TextEncoder().encode(fileJson)
+						const fileBuffer = new TextEncoder().encode(JSON.stringify(fileData))
 						socket.emit(SyncMessageType.ServerBroadcast, `${fileId}`, fileBuffer, [])
 					}
 				}
 				prevSyncedFilesRef.current = currentFileHashes
-				logSyncResult('websocket', { status: 'sync success', elementsCount: elements.length })
 			} else {
-				logSyncResult('websocket', { status: 'sync success', elementsCount: elements.length })
 				prevSyncedFilesRef.current = {}
 			}
+
+			pendingWebSocketSyncRef.current = false
+			logSyncResult('websocket', { status: 'sync success', elementsCount: syncedElementsCount })
 		} catch (error) {
 			logger.error('[Sync] WebSocket sync failed:', error)
 			logSyncResult('websocket', { status: 'sync error', error: error instanceof Error ? error.message : String(error) })
 		}
-	}, [fileId, excalidrawAPI, socket, collabStatus, isReadOnly])
+	}, [fileId, socket, collabStatus, isReadOnly, getLatestSnapshot])
 
 	const throttledSyncToLocal = useMemo(() =>
-		// Use both leading and trailing edge executions to ensure changes are saved immediately and after delay
 		throttle(doSyncToLocal, LOCAL_SYNC_DELAY, { leading: true, trailing: true })
 	, [doSyncToLocal])
 
 	const throttledSyncToServerAPI = useMemo(() =>
-		// Use both leading and trailing edge executions for server sync
-		throttle(doSyncToServerAPI, SERVER_API_SYNC_DELAY, { leading: true, trailing: true })
+		throttle(doSyncToServerAPI, SERVER_API_SYNC_DELAY, { leading: false, trailing: true })
 	, [doSyncToServerAPI])
 
 	const throttledSyncViaWebSocket = useMemo(() =>
-		// Use both leading and trailing edge executions for WebSocket sync
-		throttle(doSyncViaWebSocket, WEBSOCKET_SYNC_DELAY, { leading: true, trailing: true })
+		throttle(() => {
+			doSyncViaWebSocket().catch((error) => {
+				logger.error('[Sync] Throttled WebSocket sync failed:', error)
+			})
+		}, WEBSOCKET_SYNC_DELAY, { leading: false, trailing: true })
 	, [doSyncViaWebSocket])
 
-	// --- Cursor Sync ---
+	useEffect(() => {
+		if (pendingLocalSyncRef.current && isWorkerReady && worker && fileId && excalidrawAPI && !isReadOnly) {
+			throttledSyncToLocal()
+		}
+
+		if (pendingWebSocketSyncRef.current && fileId && socket && collabStatus === 'online' && !isReadOnly) {
+			throttledSyncViaWebSocket()
+		}
+
+		if (
+			pendingServerSyncRef.current
+			&& isWorkerReady
+			&& worker
+			&& fileId
+			&& excalidrawAPI
+			&& isDedicatedSyncer
+			&& !isReadOnly
+			&& collabStatus === 'online'
+		) {
+			throttledSyncToServerAPI()
+		}
+	}, [
+		collabStatus,
+		excalidrawAPI,
+		fileId,
+		isDedicatedSyncer,
+		isReadOnly,
+		isWorkerReady,
+		socket,
+		throttledSyncToLocal,
+		throttledSyncToServerAPI,
+		throttledSyncViaWebSocket,
+		worker,
+	])
+
 	const doSyncCursors = useCallback(
 		(payload: {
 			pointer: { x: number; y: number; tool: 'pointer' | 'laser' }
@@ -250,8 +357,7 @@ export function useSync() {
 						selectedElementIds: excalidrawAPI.getAppState().selectedElementIds,
 					},
 				}
-				const json = JSON.stringify(data)
-				const encodedBuffer = new TextEncoder().encode(json)
+				const encodedBuffer = new TextEncoder().encode(JSON.stringify(data))
 				socket.emit(SyncMessageType.ServerVolatileBroadcast, `${fileId}`, encodedBuffer)
 				logSyncResult('cursor', { status: 'sync success' })
 			} catch (error) {
@@ -262,7 +368,6 @@ export function useSync() {
 		[fileId, excalidrawAPI, socket, collabStatus],
 	)
 
-	// --- Viewport Sync ---
 	const lastBroadcastedViewportRef = useRef({ scrollX: 0, scrollY: 0, zoom: 1 })
 
 	const doSyncViewport = useCallback(
@@ -274,14 +379,12 @@ export function useSync() {
 			const { scrollX, scrollY, zoom } = appState
 			const lastViewport = lastBroadcastedViewportRef.current
 
-			// Only broadcast if viewport has changed significantly
 			if (
 				Math.abs(scrollX - lastViewport.scrollX) > 5
 				|| Math.abs(scrollY - lastViewport.scrollY) > 5
 				|| Math.abs(zoom.value - lastViewport.zoom) > 0.01
 			) {
 				try {
-					// Get current user ID for viewport tracking
 					const { getJWT, parseJwt } = useJWTStore.getState()
 					const jwt = await getJWT()
 					const jwtPayload = jwt ? parseJwt(jwt) : null
@@ -296,8 +399,7 @@ export function useSync() {
 							zoom: zoom.value,
 						},
 					}
-					const json = JSON.stringify(data)
-					const encodedBuffer = new TextEncoder().encode(json)
+					const encodedBuffer = new TextEncoder().encode(JSON.stringify(data))
 					socket.emit(SyncMessageType.ServerVolatileBroadcast, `${fileId}`, encodedBuffer)
 
 					lastBroadcastedViewportRef.current = { scrollX, scrollY, zoom: zoom.value }
@@ -317,32 +419,37 @@ export function useSync() {
 		throttle(doSyncViewport, CURSOR_SYNC_DELAY, { leading: true, trailing: true })
 	, [doSyncViewport])
 
-	// --- Event Handlers ---
-	const onChange = useCallback(() => {
-		// Update cached state immediately on every change
-		if (excalidrawAPI) {
-			const elements = excalidrawAPI.getSceneElementsIncludingDeleted()
-			const files = excalidrawAPI.getFiles()
-			cachedStateRef.current = { elements, files }
+	const onChange = useCallback((
+		elements?: readonly ExcalidrawElement[],
+		appState?: AppState,
+		files?: BinaryFiles,
+	) => {
+		pendingLocalSyncRef.current = true
+		pendingServerSyncRef.current = true
+		pendingWebSocketSyncRef.current = true
+
+		const snapshot = captureSnapshot(elements, appState, files)
+		if (snapshot) {
+			latestSnapshotRef.current = snapshot
 		}
 
 		throttledSyncToLocal()
 		throttledSyncToServerAPI()
 		throttledSyncViaWebSocket()
 
-		// Sync viewport changes
-		if (excalidrawAPI) {
-			const appState = excalidrawAPI.getAppState()
+		if (appState) {
 			throttledSyncViewport(appState)
+		} else if (excalidrawAPI) {
+			throttledSyncViewport(excalidrawAPI.getAppState())
 		}
 
 		logger.debug('[Sync] Changes detected, triggered sync operations')
-	}, [throttledSyncToLocal, throttledSyncToServerAPI, throttledSyncViaWebSocket, throttledSyncViewport, excalidrawAPI])
+	}, [captureSnapshot, throttledSyncToLocal, throttledSyncToServerAPI, throttledSyncViaWebSocket, throttledSyncViewport, excalidrawAPI])
 
 	const onPointerUpdate = useCallback(
 		(payload: {
-			pointersMap: Map<string, { x: number; y: number }>,
-			pointer: { x: number; y: number; tool: 'laser' | 'pointer' },
+			pointersMap: Map<string, { x: number; y: number }>
+			pointer: { x: number; y: number; tool: 'laser' | 'pointer' }
 			button: 'down' | 'up'
 		}) => {
 			if (payload.pointersMap.size < 2) {
@@ -352,30 +459,12 @@ export function useSync() {
 		[throttledSyncCursors],
 	)
 
-	// Capture syncer state immediately to avoid closure issues
-	const isSyncerRef = useRef(isDedicatedSyncer)
-	useEffect(() => {
-		if (isDedicatedSyncer !== isSyncerRef.current) {
-			// eslint-disable-next-line no-console
-			console.log('[Sync] SYNCER STATUS:', isDedicatedSyncer ? 'DESIGNATED AS SYNCER' : 'NOT SYNCER')
-			isSyncerRef.current = isDedicatedSyncer
-		}
-	}, [isDedicatedSyncer])
-
-	// Cache the latest state for final sync - update on EVERY change
-	const cachedStateRef = useRef<{ elements: readonly ExcalidrawElement[]; files: BinaryFiles }>({ elements: [], files: {} as BinaryFiles })
-
-	// Direct sync when leaving - synchronous to ensure it completes
 	const doFinalServerSync = useCallback(() => {
 		if (!fileId || !isSyncerRef.current) {
 			return
 		}
 
-		// eslint-disable-next-line no-console
-		console.log('[Sync] Executing final sync on page leave')
-
 		try {
-			// Get JWT from store - it's stored in tokens[fileId]
 			const jwtState = useJWTStore.getState()
 			const jwt = jwtState.tokens[fileId]
 
@@ -383,82 +472,115 @@ export function useSync() {
 				return
 			}
 
-			// Use CACHED state instead of trying to get it now (might be cleared already)
-			const { elements, files } = cachedStateRef.current
-			// eslint-disable-next-line no-console
-			console.log('[Sync] Using cached state with', elements.length, 'elements')
-
+			const snapshot = getLatestSnapshot()
 			const url = generateUrl(`apps/whiteboard/${fileId}`)
 
 			const data = JSON.stringify({
-				data: { elements, files: files || {} },
+				data: { elements: snapshot.elements, files: snapshot.files || {} },
 			})
 
-			// Use synchronous XMLHttpRequest (works in beforeunload)
 			const xhr = new XMLHttpRequest()
-			xhr.open('PUT', url, false) // false = synchronous
+			xhr.open('PUT', url, false)
 			xhr.setRequestHeader('Content-Type', 'application/json')
 			xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest')
 			xhr.setRequestHeader('Authorization', `Bearer ${jwt}`)
-
 			xhr.send(data)
-			// eslint-disable-next-line no-console
-			console.log('[Sync] Final sync done, status:', xhr.status)
 		} catch (error) {
-			// eslint-disable-next-line no-console
 			console.error('[Sync] Final sync failed:', error)
 		}
-	}, [fileId])
+	}, [fileId, getLatestSnapshot])
+
+	const excalidrawAPIRef = useRef(excalidrawAPI)
+	const isReadOnlyRef = useRef(isReadOnly)
+	const doSyncToLocalRef = useRef(doSyncToLocal)
+	const doFinalServerSyncRef = useRef(doFinalServerSync)
+	const throttledSyncToLocalRef = useRef(throttledSyncToLocal)
+	const throttledSyncToServerAPIRef = useRef(throttledSyncToServerAPI)
+	const throttledSyncViaWebSocketRef = useRef(throttledSyncViaWebSocket)
+	const throttledSyncCursorsRef = useRef(throttledSyncCursors)
 
 	useEffect(() => {
-		const handleBeforeUnload = () => {
-			if (excalidrawAPI && !isReadOnly && isSyncerRef.current) {
-				// eslint-disable-next-line no-console
-				console.log('[Sync] Page unloading - syncing as dedicated syncer')
-				// Cancel any pending throttled trailing call FIRST
-				throttledSyncToLocal.cancel()
-				throttledSyncToServerAPI.cancel()
-				// Call the unthrottled versions directly
-				doSyncToLocal()
-				doFinalServerSync()
+		excalidrawAPIRef.current = excalidrawAPI
+	}, [excalidrawAPI])
+
+	useEffect(() => {
+		isReadOnlyRef.current = isReadOnly
+	}, [isReadOnly])
+
+	useEffect(() => {
+		doSyncToLocalRef.current = doSyncToLocal
+	}, [doSyncToLocal])
+
+	useEffect(() => {
+		doFinalServerSyncRef.current = doFinalServerSync
+	}, [doFinalServerSync])
+
+	useEffect(() => {
+		throttledSyncToLocalRef.current = throttledSyncToLocal
+	}, [throttledSyncToLocal])
+
+	useEffect(() => {
+		throttledSyncToServerAPIRef.current = throttledSyncToServerAPI
+	}, [throttledSyncToServerAPI])
+
+	useEffect(() => {
+		throttledSyncViaWebSocketRef.current = throttledSyncViaWebSocket
+	}, [throttledSyncViaWebSocket])
+
+	useEffect(() => {
+		throttledSyncCursorsRef.current = throttledSyncCursors
+	}, [throttledSyncCursors])
+
+	useEffect(() => {
+		const flushFinalSync = (reason: 'unload' | 'visibility change') => {
+			if (!excalidrawAPIRef.current || isReadOnlyRef.current || !isSyncerRef.current) {
+				return
 			}
+
+			throttledSyncToLocalRef.current.cancel()
+			throttledSyncToServerAPIRef.current.cancel()
+			doSyncToLocalRef.current().catch((error) => {
+				logger.error(`[Sync] Final local sync on ${reason} failed:`, error)
+			})
+			doFinalServerSyncRef.current()
 		}
 
-		// Also handle visibility change as backup for mobile/tabs
+		const handleBeforeUnload = () => {
+			flushFinalSync('unload')
+		}
+
 		const handleVisibilityChange = () => {
-			if (document.visibilityState === 'hidden' && isSyncerRef.current && excalidrawAPI && !isReadOnly) {
-				throttledSyncToLocal.cancel()
-				throttledSyncToServerAPI.cancel()
-				doSyncToLocal()
-				doFinalServerSync()
+			if (document.visibilityState === 'hidden') {
+				flushFinalSync('visibility change')
 			}
 		}
 
 		window.addEventListener('beforeunload', handleBeforeUnload)
 		document.addEventListener('visibilitychange', handleVisibilityChange)
 
-		// Cleanup function for component unmount
 		return () => {
 			window.removeEventListener('beforeunload', handleBeforeUnload)
 			document.removeEventListener('visibilitychange', handleVisibilityChange)
+		}
+	}, [])
 
-			// If we're the dedicated syncer and unmounting, do a final sync
-			if (isSyncerRef.current && excalidrawAPI && !isReadOnly) {
-				// Cancel pending throttled calls
-				throttledSyncToLocal.cancel()
-				throttledSyncToServerAPI.cancel()
-				// Do final syncs
-				doSyncToLocal()
-				doFinalServerSync()
+	useEffect(() => {
+		return () => {
+			if (isSyncerRef.current && excalidrawAPIRef.current && !isReadOnlyRef.current) {
+				throttledSyncToLocalRef.current.cancel()
+				throttledSyncToServerAPIRef.current.cancel()
+				doSyncToLocalRef.current().catch((error) => {
+					logger.error('[Sync] Final local sync on cleanup failed:', error)
+				})
+				doFinalServerSyncRef.current()
 			}
 
-			// Cancel all throttled functions to prevent them from running after unmount
-			throttledSyncToLocal.cancel()
-			throttledSyncToServerAPI.cancel()
-			throttledSyncViaWebSocket.cancel()
-			throttledSyncCursors.cancel()
+			throttledSyncToLocalRef.current.cancel()
+			throttledSyncToServerAPIRef.current.cancel()
+			throttledSyncViaWebSocketRef.current.cancel()
+			throttledSyncCursorsRef.current.cancel()
 		}
-	}, [doSyncToLocal, doSyncToServerAPI, doFinalServerSync, throttledSyncToLocal, throttledSyncToServerAPI, throttledSyncViaWebSocket, throttledSyncCursors, excalidrawAPI, isReadOnly])
+	}, [])
 
 	return { onChange, onPointerUpdate }
 }

--- a/src/stores/useCollaborationStore.ts
+++ b/src/stores/useCollaborationStore.ts
@@ -18,37 +18,40 @@ interface AuthErrorState {
 	message: string | null
 	consecutiveFailures: number
 	lastFailureTime: number | null
-	isPersistent: boolean // True when we've detected a persistent auth issue (likely JWT secret mismatch)
+	isPersistent: boolean
 }
 
 interface CollaborationStore {
 	status: CollaborationConnectionStatus
 	socket: CollaborationSocket | null
-	isDedicatedSyncer: boolean // Is this client responsible for syncing to server/broadcasting?
+	isDedicatedSyncer: boolean
 	authError: AuthErrorState
-	followedUserId: string | null // User ID being followed for viewport synchronization
-	isInRoom: boolean // Whether the socket has joined the current room
+	followedUserId: string | null
+	isInRoom: boolean
+	lastSceneHash: number | null
+	broadcastedElementVersions: Record<string, number>
 
-	// Presentation state
-	presenterId: string | null // User ID of current presenter
-	isPresentationMode: boolean // Whether presentation mode is active in the room
-	isPresenting: boolean // Whether current user is presenting
-	presentationStartTime: number | null // When presentation started
-	autoFollowPresenter: boolean // Whether to automatically follow presenter (can be disabled by user)
+	presenterId: string | null
+	isPresentationMode: boolean
+	isPresenting: boolean
+	presentationStartTime: number | null
+	autoFollowPresenter: boolean
 
 	votings: Voting[]
 
-	// Actions
 	setStatus: (status: CollaborationConnectionStatus) => void
 	setSocket: (socket: CollaborationSocket | null) => void
 	setDedicatedSyncer: (isSyncer: boolean) => void
 	setIsInRoom: (inRoom: boolean) => void
+	setLastSceneHash: (hash: number | null) => void
+	replaceBroadcastedElementVersions: (versions: Record<string, number>) => void
+	mergeBroadcastedElementVersions: (versions: Record<string, number>) => void
+	resetSceneSyncState: () => void
 	setAuthError: (error: Partial<AuthErrorState>) => void
 	incrementAuthFailure: (errorType: AuthErrorType, message: string) => void
 	clearAuthError: () => void
 	resetStore: () => void
 
-	// Presentation actions
 	setPresentationState: (state: {
 		presenterId?: string | null
 		isPresentationMode?: boolean
@@ -57,7 +60,6 @@ interface CollaborationStore {
 	}) => void
 	setAutoFollowPresenter: (autoFollow: boolean) => void
 
-	// Voting actions
 	addVoting: (voting: Voting) => void
 	updateVoting: (voting: Voting) => void
 	setVotings: (votings: Voting[]) => void
@@ -71,15 +73,35 @@ const initialAuthErrorState: AuthErrorState = {
 	isPersistent: false,
 }
 
-const initialState: Omit<CollaborationStore, 'setStatus' | 'setSocket' | 'setDedicatedSyncer' | 'setAuthError' | 'incrementAuthFailure' | 'clearAuthError' | 'resetStore' | 'setPresentationState' | 'setAutoFollowPresenter' | 'addVoting' | 'updateVoting' | 'setVotings'> = {
+const initialState: Omit<
+CollaborationStore,
+| 'setStatus'
+| 'setSocket'
+| 'setDedicatedSyncer'
+| 'setIsInRoom'
+| 'setLastSceneHash'
+| 'replaceBroadcastedElementVersions'
+| 'mergeBroadcastedElementVersions'
+| 'resetSceneSyncState'
+| 'setAuthError'
+| 'incrementAuthFailure'
+| 'clearAuthError'
+| 'resetStore'
+| 'setPresentationState'
+| 'setAutoFollowPresenter'
+| 'addVoting'
+| 'updateVoting'
+| 'setVotings'
+> = {
 	status: 'offline',
 	socket: null,
 	isDedicatedSyncer: false,
 	authError: initialAuthErrorState,
 	followedUserId: null,
 	isInRoom: false,
+	lastSceneHash: null,
+	broadcastedElementVersions: {},
 
-	// Presentation initial state
 	presenterId: null,
 	isPresentationMode: false,
 	isPresenting: false,
@@ -89,9 +111,8 @@ const initialState: Omit<CollaborationStore, 'setStatus' | 'setSocket' | 'setDed
 	votings: [],
 }
 
-// Constants for auth failure detection
 const MAX_AUTH_FAILURES = 3
-const PERSISTENT_FAILURE_THRESHOLD = 5 * 60 * 1000 // 5 minutes
+const PERSISTENT_FAILURE_THRESHOLD = 5 * 60 * 1000
 
 export const useCollaborationStore = create<CollaborationStore>()((set) => ({
 	...initialState,
@@ -100,6 +121,20 @@ export const useCollaborationStore = create<CollaborationStore>()((set) => ({
 	setSocket: (socket) => set({ socket }),
 	setDedicatedSyncer: (isSyncer) => set({ isDedicatedSyncer: isSyncer }),
 	setIsInRoom: (inRoom) => set({ isInRoom: inRoom }),
+	setLastSceneHash: (hash) => set({ lastSceneHash: hash }),
+	replaceBroadcastedElementVersions: (versions) => set({ broadcastedElementVersions: versions }),
+	mergeBroadcastedElementVersions: (versions) => set((state) => ({
+		broadcastedElementVersions: Object.entries(versions).reduce<Record<string, number>>((nextVersions, [id, version]) => {
+			nextVersions[id] = nextVersions[id] === undefined
+				? version
+				: Math.max(nextVersions[id], version)
+			return nextVersions
+		}, { ...state.broadcastedElementVersions }),
+	})),
+	resetSceneSyncState: () => set({
+		lastSceneHash: null,
+		broadcastedElementVersions: {},
+	}),
 
 	setAuthError: (error) => set((state) => ({
 		authError: { ...state.authError, ...error },
@@ -108,8 +143,6 @@ export const useCollaborationStore = create<CollaborationStore>()((set) => ({
 	incrementAuthFailure: (errorType, message) => set((state) => {
 		const now = Date.now()
 		const newFailureCount = state.authError.consecutiveFailures + 1
-
-		// Determine if this is a persistent issue (likely JWT secret mismatch)
 		const isPersistent = newFailureCount >= MAX_AUTH_FAILURES
 			&& (state.authError.lastFailureTime === null
 			 || now - state.authError.lastFailureTime < PERSISTENT_FAILURE_THRESHOLD)
@@ -129,7 +162,6 @@ export const useCollaborationStore = create<CollaborationStore>()((set) => ({
 
 	resetStore: () => set(initialState),
 
-	// Presentation actions
 	setPresentationState: (state) => set((currentState) => ({
 		...currentState,
 		...state,
@@ -137,7 +169,6 @@ export const useCollaborationStore = create<CollaborationStore>()((set) => ({
 
 	setAutoFollowPresenter: (autoFollow) => set({ autoFollowPresenter: autoFollow }),
 
-	// Voting actions
 	addVoting: (voting) => set((state) => ({
 		votings: [...state.votings, voting],
 	})),

--- a/src/stores/useExcalidrawStore.ts
+++ b/src/stores/useExcalidrawStore.ts
@@ -14,11 +14,41 @@ interface ExcalidrawStore {
 	scrollToContent: () => void
 }
 
+type WhiteboardTestHooks = {
+	excalidrawStore?: {
+		getState?: () => {
+			excalidrawAPI: ExcalidrawImperativeAPI | null
+		}
+	}
+}
+
+declare global {
+	interface Window {
+		__whiteboardTest?: boolean
+		__whiteboardTestHooks?: WhiteboardTestHooks & Record<string, unknown>
+	}
+}
+
+const attachTestHooks = () => {
+	if (typeof window === 'undefined' || !window.__whiteboardTest) {
+		return
+	}
+
+	window.__whiteboardTestHooks = window.__whiteboardTestHooks || {}
+	window.__whiteboardTestHooks.excalidrawStore = useExcalidrawStore
+}
+
 export const useExcalidrawStore = create<ExcalidrawStore>((set, get) => ({
 	excalidrawAPI: null,
 
-	setExcalidrawAPI: (api: ExcalidrawImperativeAPI) => set({ excalidrawAPI: api }),
-	resetExcalidrawAPI: () => set({ excalidrawAPI: null }),
+	setExcalidrawAPI: (api: ExcalidrawImperativeAPI) => {
+		set({ excalidrawAPI: api })
+		attachTestHooks()
+	},
+	resetExcalidrawAPI: () => {
+		set({ excalidrawAPI: null })
+		attachTestHooks()
+	},
 	scrollToContent: () => {
 		const { excalidrawAPI } = get()
 		if (!excalidrawAPI) return
@@ -31,3 +61,5 @@ export const useExcalidrawStore = create<ExcalidrawStore>((set, get) => ({
 		})
 	},
 }))
+
+attachTestHooks()

--- a/src/stores/useSyncStore.ts
+++ b/src/stores/useSyncStore.ts
@@ -113,6 +113,19 @@ export const useSyncStore = create<SyncStore>((set, get) => ({
 					}
 				}
 
+				syncWorker.onerror = (event) => {
+					logger.error('[SyncStore] Worker runtime error:', {
+						message: event.message,
+						filename: event.filename,
+						lineno: event.lineno,
+						colno: event.colno,
+					})
+				}
+
+				syncWorker.onmessageerror = (event) => {
+					logger.error('[SyncStore] Worker message error:', event)
+				}
+
 				// Initialize the worker
 				syncWorker.postMessage({
 					type: 'INIT',
@@ -139,3 +152,25 @@ export const useSyncStore = create<SyncStore>((set, get) => ({
 		}
 	},
 }))
+
+type WhiteboardTestHooks = {
+	syncStore?: typeof useSyncStore
+}
+
+declare global {
+	interface Window {
+		__whiteboardTest?: boolean
+		__whiteboardTestHooks?: WhiteboardTestHooks & Record<string, unknown>
+	}
+}
+
+const attachTestHooks = () => {
+	if (typeof window === 'undefined' || !window.__whiteboardTest) {
+		return
+	}
+
+	window.__whiteboardTestHooks = window.__whiteboardTestHooks || {}
+	window.__whiteboardTestHooks.syncStore = useSyncStore
+}
+
+attachTestHooks()

--- a/src/types/collaboration.ts
+++ b/src/types/collaboration.ts
@@ -65,6 +65,7 @@ export interface ServerToClientEvents {
 export interface ClientToServerEvents {
 	'join-room': (roomId: string) => void
 	'server-broadcast': (roomId: string, payload: ArrayBuffer | Uint8Array, iv: ArrayBuffer | number[] | []) => void
+	'server-direct-broadcast': (roomId: string, targetSocketId: string, payload: ArrayBuffer | Uint8Array, iv: ArrayBuffer | number[] | []) => void
 	'server-volatile-broadcast': (roomId: string, payload: Uint8Array) => void
 	'image-get': (roomId: string, id: string) => void
 	'request-presenter-viewport': (payload: { fileId: string }) => void

--- a/src/utils/mergeElementsWithMetadata.ts
+++ b/src/utils/mergeElementsWithMetadata.ts
@@ -43,13 +43,13 @@ export function mergeElementsWithMetadata(
 		const whiteboardElement = element as WhiteboardElement
 		const remoteElement = remoteElementsMap.get(element.id)
 		const localElement = localElementsMap.get(element.id)
+		const customData = { ...(whiteboardElement.customData || {}) }
+		let hasCustomDataChanges = false
 
 		// If remote element has creator info, preserve it
 		if (remoteElement?.customData?.creator) {
-			if (!whiteboardElement.customData) {
-				whiteboardElement.customData = {}
-			}
-			whiteboardElement.customData.creator = remoteElement.customData.creator
+			customData.creator = remoteElement.customData.creator
+			hasCustomDataChanges = true
 		}
 
 		// If remote element has lastModifiedBy info, check if it's newer
@@ -58,43 +58,45 @@ export function mergeElementsWithMetadata(
 			const localModTime = localElement?.customData?.lastModifiedBy?.createdAt || 0
 
 			if (remoteModTime > localModTime) {
-				if (!whiteboardElement.customData) {
-					whiteboardElement.customData = {}
-				}
-				whiteboardElement.customData.lastModifiedBy = remoteElement.customData.lastModifiedBy
+				customData.lastModifiedBy = remoteElement.customData.lastModifiedBy
+				hasCustomDataChanges = true
 			}
 		}
 
 		// If local element had creator info but remote doesn't, preserve local
 		if (localElement?.customData?.creator && !whiteboardElement.customData?.creator) {
-			if (!whiteboardElement.customData) {
-				whiteboardElement.customData = {}
-			}
-			whiteboardElement.customData.creator = localElement.customData.creator
+			customData.creator = localElement.customData.creator
+			hasCustomDataChanges = true
 		}
 
 		// Preserve table-specific custom data from whichever version won reconciliation
 		// This ensures tableHtml, isTable, and tableLock are not lost
 		const sourceElement = remoteElement || localElement
 		if (sourceElement?.customData) {
-			if (!whiteboardElement.customData) {
-				whiteboardElement.customData = {}
-			}
-
 			// Preserve table metadata
 			if (sourceElement.customData.isTable !== undefined) {
-				whiteboardElement.customData.isTable = sourceElement.customData.isTable
+				customData.isTable = sourceElement.customData.isTable
+				hasCustomDataChanges = true
 			}
 			if (sourceElement.customData.tableHtml !== undefined) {
-				whiteboardElement.customData.tableHtml = sourceElement.customData.tableHtml
+				customData.tableHtml = sourceElement.customData.tableHtml
+				hasCustomDataChanges = true
 			}
 			// Preserve or clear lock status from the source element
 			if ('tableLock' in sourceElement.customData) {
-				whiteboardElement.customData.tableLock = sourceElement.customData.tableLock
+				customData.tableLock = sourceElement.customData.tableLock
+				hasCustomDataChanges = true
 			}
 		}
 
-		return whiteboardElement
+		if (!hasCustomDataChanges) {
+			return whiteboardElement
+		}
+
+		return {
+			...whiteboardElement,
+			customData,
+		}
 	})
 
 	return finalElements

--- a/src/utils/syncSceneData.ts
+++ b/src/utils/syncSceneData.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type { ExcalidrawElement } from '@excalidraw/excalidraw/types/element/types'
-import type { AppState } from '@excalidraw/excalidraw/types/types'
+import type { ExcalidrawElement } from '@nextcloud/excalidraw/dist/types/excalidraw/element/types'
+import type { AppState } from '@nextcloud/excalidraw/dist/types/excalidraw/types'
 import { isObject } from 'lodash'
 
 /**
@@ -14,34 +14,97 @@ import { isObject } from 'lodash'
 export const computeElementVersionHash = (
 	elements: readonly ExcalidrawElement[],
 ): number => {
-	let hash = 5381 // djb2 starting point
+	// Keep this hash worker-safe: importing the full excalidraw runtime pulls in
+	// browser-only globals such as `window`, which breaks the sync worker.
+	let hash = 5381
+	for (let i = 0; i < elements.length; i++) {
+		hash = (hash << 5) + hash + elements[i].versionNonce
+	}
+	return hash >>> 0
+}
 
-	// Special case: empty elements array should have a unique hash
-	// This ensures that when all elements are deleted, the hash changes
-	if (elements.length === 0) {
-		return 1 // Special hash for empty array
+export const buildBroadcastedElementVersions = (
+	elements: readonly ExcalidrawElement[],
+): Record<string, number> => {
+	return elements.reduce<Record<string, number>>((versions, element) => {
+		versions[element.id] = element.version
+		return versions
+	}, {})
+}
+
+export const mergeBroadcastedElementVersions = (
+	currentVersions: Record<string, number>,
+	elements: readonly ExcalidrawElement[],
+): Record<string, number> => {
+	const nextVersions = { ...currentVersions }
+
+	elements.forEach((element) => {
+		const currentVersion = nextVersions[element.id]
+		nextVersions[element.id] = currentVersion === undefined
+			? element.version
+			: Math.max(currentVersion, element.version)
+	})
+
+	return nextVersions
+}
+
+export const getIncrementalSceneElements = (
+	elements: readonly ExcalidrawElement[],
+	broadcastedElementVersions: Record<string, number>,
+): readonly ExcalidrawElement[] => {
+	return elements.filter((element) => broadcastedElementVersions[element.id] !== element.version)
+}
+
+type SceneSyncPlanNoop = {
+	type: 'noop'
+}
+
+type SceneSyncPlanAdvance = {
+	type: 'advance'
+	sceneHash: number
+	broadcastedElementVersions: Record<string, number>
+}
+
+type SceneSyncPlanBroadcast = {
+	type: 'broadcast'
+	sceneHash: number
+	sceneElements: readonly ExcalidrawElement[]
+	broadcastedElementVersions: Record<string, number>
+}
+
+export type IncrementalSceneSyncPlan = SceneSyncPlanNoop | SceneSyncPlanAdvance | SceneSyncPlanBroadcast
+
+export const planIncrementalSceneSync = ({
+	elements,
+	broadcastedElementVersions,
+	lastSceneHash,
+}: {
+	elements: readonly ExcalidrawElement[]
+	broadcastedElementVersions: Record<string, number>
+	lastSceneHash: number | null
+}): IncrementalSceneSyncPlan => {
+	const sceneHash = computeElementVersionHash(elements)
+
+	if (lastSceneHash === sceneHash) {
+		return { type: 'noop' }
 	}
 
-	// Count deleted elements to ensure hash changes when elements are deleted
-	let deletedCount = 0
+	const incrementalElements = getIncrementalSceneElements(elements, broadcastedElementVersions)
 
-	for (const el of elements) {
-		// Combine version, nonce, and deletion status into the hash
-		// Using prime numbers helps distribute values
-		hash = (hash * 33) ^ (el.version || 0)
-		hash = (hash * 33) ^ (el.versionNonce || 0)
-
-		// Track deletion status
-		if (el.isDeleted) {
-			deletedCount++
-			hash = (hash * 33) ^ 1 // Include isDeleted status
+	if (incrementalElements.length === 0) {
+		return {
+			type: 'advance',
+			sceneHash,
+			broadcastedElementVersions: buildBroadcastedElementVersions(elements),
 		}
 	}
 
-	// Include deleted count in the hash to ensure it changes when elements are deleted
-	hash = (hash * 33) ^ deletedCount
-
-	return hash >>> 0 // Ensure positive integer
+	return {
+		type: 'broadcast',
+		sceneHash,
+		sceneElements: incrementalElements,
+		broadcastedElementVersions: buildBroadcastedElementVersions(incrementalElements),
+	}
 }
 
 /**

--- a/src/utils/tableLocking.ts
+++ b/src/utils/tableLocking.ts
@@ -7,6 +7,7 @@ import { showError } from '@nextcloud/dialogs'
 import { t } from '@nextcloud/l10n'
 import type { ExcalidrawImperativeAPI } from '@nextcloud/excalidraw/dist/types/excalidraw/types'
 import type { ExcalidrawImageElement } from '@nextcloud/excalidraw/dist/types/excalidraw/element/types'
+import { updateElementCustomData } from './updateElementCustomData'
 
 const LOCK_TIMEOUT_MS = 5 * 60 * 1000 // 5 minutes
 
@@ -91,14 +92,10 @@ export function setLockOnElement(
 	if (idx === -1) return
 
 	// Update the element with the new lock state
-	elements[idx] = {
-		...elements[idx],
-		customData: {
-			...elements[idx].customData,
-			// Set tableLock to the provided value, or explicitly undefined to clear
-			...(lock ? { tableLock: lock } : { tableLock: undefined }),
-		},
-	}
+	elements[idx] = updateElementCustomData(elements[idx], (customData) => ({
+		...customData,
+		...(lock ? { tableLock: lock } : { tableLock: undefined }),
+	}))
 	// Trigger onChange which syncs to other users
 	excalidrawAPI.updateScene({ elements })
 }

--- a/src/utils/updateElementCustomData.ts
+++ b/src/utils/updateElementCustomData.ts
@@ -1,0 +1,20 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { newElementWith } from '@nextcloud/excalidraw'
+import type { ExcalidrawElement } from '@nextcloud/excalidraw/dist/types/excalidraw/element/types'
+
+export function updateElementCustomData<T extends ExcalidrawElement>(
+	element: T,
+	updater: (currentCustomData: Record<string, unknown>) => Record<string, unknown>,
+): T {
+	const currentCustomData = (element.customData && typeof element.customData === 'object')
+		? element.customData as Record<string, unknown>
+		: {}
+
+	return newElementWith(element, {
+		customData: updater(currentCustomData),
+	} as Partial<T>) as T
+}

--- a/tests/integration/multinode-redis.spec.mjs
+++ b/tests/integration/multinode-redis.spec.mjs
@@ -417,6 +417,54 @@ describe('Multi node websocket cluster with redis streams', () => {
 		})
 	})
 
+	it('delivers direct scene broadcasts across nodes only to the targeted socket', async () => {
+		const roomID = 'room-direct-scene'
+		const senderToken = buildToken(roomID, { id: 'sender', name: 'Sender', displayName: 'Sender' })
+		const targetToken = buildToken(roomID, { id: 'target', name: 'Target', displayName: 'Target' })
+		const observerToken = buildToken(roomID, { id: 'observer', name: 'Observer', displayName: 'Observer' })
+
+		const senderSocket = createSocket(serverAUrl, senderToken)
+		await waitFor(senderSocket, 'connect')
+		senderSocket.emit('join-room', roomID)
+		await waitFor(senderSocket, 'sync-designate')
+
+		const targetSocket = createSocket(serverBUrl, targetToken)
+		await waitFor(targetSocket, 'connect')
+		targetSocket.emit('join-room', roomID)
+		await waitFor(targetSocket, 'sync-designate')
+
+		const observerSocket = createSocket(serverBUrl, observerToken)
+		await waitFor(observerSocket, 'connect')
+		observerSocket.emit('join-room', roomID)
+		await waitFor(observerSocket, 'sync-designate')
+
+		const payload = new TextEncoder().encode(JSON.stringify({
+			type: 'SCENE_INIT',
+			payload: {
+				elements: [{ id: 'shape-1' }],
+			},
+		}))
+		const targetMessagePromise = waitFor(targetSocket, 'client-broadcast')
+		const observerMessages = []
+		observerSocket.on('client-broadcast', (...args) => {
+			observerMessages.push(args)
+		})
+
+		senderSocket.emit('server-direct-broadcast', roomID, targetSocket.id, payload, [])
+
+		const receivedPayload = await Promise.race([
+			targetMessagePromise,
+			new Promise((_resolve, reject) =>
+				setTimeout(() => reject(new Error('Timeout waiting for targeted client-broadcast event')), 2000),
+			),
+		])
+		const decodedPayload = JSON.parse(new TextDecoder().decode(receivedPayload))
+
+		expect(decodedPayload.type).toBe('SCENE_INIT')
+		await new Promise(resolve => setTimeout(resolve, 200))
+		expect(observerMessages).toHaveLength(0)
+	})
+
 	it('broadcasts a presentation stop when the presenter node shuts down', async () => {
 		const roomID = 'room-presenter-shutdown'
 		const presenterToken = buildToken(roomID, { id: 'shutdown-presenter', name: 'Presenter', displayName: 'Presenter' })

--- a/tests/integration/socket.spec.mjs
+++ b/tests/integration/socket.spec.mjs
@@ -204,4 +204,155 @@ describe('Socket handling', () => {
 		newSocket.disconnect()
 	})
 
+	it('clears the old syncer when the room empties', async () => {
+		const roomID = 456
+
+		const bobSocket = io(Config.NEXTCLOUD_URL, {
+			auth: {
+				token: jwt.sign(
+					{
+						roomID,
+						user: { id: 'bob-user', name: 'Bob' },
+					},
+					Config.JWT_SECRET_KEY,
+				),
+			},
+		})
+
+		await waitFor(bobSocket, 'connect')
+		const bobDesignationPromise = waitFor(bobSocket, 'sync-designate')
+		bobSocket.emit('join-room', roomID)
+		const bobDesignation = await bobDesignationPromise
+		expect(bobDesignation.isSyncer).toBe(true)
+
+		bobSocket.disconnect()
+		await new Promise(resolve => setTimeout(resolve, 100))
+
+		const adminSocket = io(Config.NEXTCLOUD_URL, {
+			auth: {
+				token: jwt.sign(
+					{
+						roomID,
+						user: { id: 'admin-user', name: 'Admin' },
+					},
+					Config.JWT_SECRET_KEY,
+				),
+			},
+		})
+
+		await waitFor(adminSocket, 'connect')
+		const adminDesignationPromise = waitFor(adminSocket, 'sync-designate')
+		adminSocket.emit('join-room', roomID)
+		const adminDesignation = await adminDesignationPromise
+		expect(adminDesignation.isSyncer).toBe(true)
+
+		const bobReconnectSocket = io(Config.NEXTCLOUD_URL, {
+			auth: {
+				token: jwt.sign(
+					{
+						roomID,
+						user: { id: 'bob-user', name: 'Bob' },
+					},
+					Config.JWT_SECRET_KEY,
+				),
+			},
+		})
+
+		await waitFor(bobReconnectSocket, 'connect')
+		const bobReconnectDesignationPromise = waitFor(bobReconnectSocket, 'sync-designate')
+		bobReconnectSocket.emit('join-room', roomID)
+		const bobReconnectDesignation = await bobReconnectDesignationPromise
+		expect(bobReconnectDesignation.isSyncer).toBe(false)
+
+		bobReconnectSocket.disconnect()
+		adminSocket.disconnect()
+	})
+
+	it('direct scene broadcasts reach only the targeted socket', async () => {
+		const roomID = 789
+		const senderSocket = io(Config.NEXTCLOUD_URL, {
+			auth: {
+				token: jwt.sign(
+					{
+						roomID,
+						user: { id: 'sender-user', name: 'Sender' },
+					},
+					Config.JWT_SECRET_KEY,
+				),
+			},
+		})
+		const targetSocket = io(Config.NEXTCLOUD_URL, {
+			auth: {
+				token: jwt.sign(
+					{
+						roomID,
+						user: { id: 'target-user', name: 'Target' },
+					},
+					Config.JWT_SECRET_KEY,
+				),
+			},
+		})
+		const observerSocket = io(Config.NEXTCLOUD_URL, {
+			auth: {
+				token: jwt.sign(
+					{
+						roomID,
+						user: { id: 'observer-user', name: 'Observer' },
+					},
+					Config.JWT_SECRET_KEY,
+				),
+			},
+		})
+
+		await Promise.all([
+			waitFor(senderSocket, 'connect'),
+			waitFor(targetSocket, 'connect'),
+			waitFor(observerSocket, 'connect'),
+		])
+
+		const senderDesignationPromise = waitFor(senderSocket, 'sync-designate')
+		const targetDesignationPromise = waitFor(targetSocket, 'sync-designate')
+		const observerDesignationPromise = waitFor(observerSocket, 'sync-designate')
+
+		senderSocket.emit('join-room', roomID)
+		targetSocket.emit('join-room', roomID)
+		observerSocket.emit('join-room', roomID)
+
+		await Promise.all([
+			senderDesignationPromise,
+			targetDesignationPromise,
+			observerDesignationPromise,
+		])
+
+		const payload = new TextEncoder().encode(JSON.stringify({
+			type: 'SCENE_INIT',
+			payload: {
+				elements: [{ id: 'shape-1' }],
+			},
+		}))
+		const targetMessagePromise = waitFor(targetSocket, 'client-broadcast')
+		const observerMessages = []
+		observerSocket.on('client-broadcast', (...args) => {
+			observerMessages.push(args)
+		})
+
+		senderSocket.emit('server-direct-broadcast', `${roomID}`, targetSocket.id, payload, [])
+
+		const receivedPayload = await Promise.race([
+			targetMessagePromise,
+			new Promise((_resolve, reject) =>
+				setTimeout(() => reject(new Error('Timeout waiting for targeted client-broadcast event')), 2000),
+			),
+		])
+		const decodedPayload = new TextDecoder().decode(receivedPayload)
+
+		expect(decodedPayload).toContain('"type":"SCENE_INIT"')
+		await new Promise(resolve => setTimeout(resolve, 200))
+		expect(observerMessages).toHaveLength(0)
+
+		senderSocket.disconnect()
+		targetSocket.disconnect()
+		observerSocket.disconnect()
+	})
+
 })

--- a/tests/integration/syncSceneData.spec.mjs
+++ b/tests/integration/syncSceneData.spec.mjs
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@nextcloud/excalidraw', () => ({
+	hashElementsVersion: vi.fn((elements = []) => elements.reduce(
+		(hash, element, index) => hash + ((element.versionNonce ?? element.version ?? 0) * (index + 1)),
+		0,
+	)),
+}))
+
+const {
+	buildBroadcastedElementVersions,
+	computeElementVersionHash,
+	getIncrementalSceneElements,
+	mergeBroadcastedElementVersions,
+	planIncrementalSceneSync,
+} = await import('../../src/utils/syncSceneData.ts')
+
+function makeElement(id, version = 1, versionNonce = version * 100) {
+	return {
+		id,
+		version,
+		versionNonce,
+	}
+}
+
+describe('syncSceneData incremental selection', () => {
+	it('selects only the changed element from a large scene', () => {
+		const originalElements = Array.from({ length: 45 }, (_value, index) =>
+			makeElement(`element-${index + 1}`),
+		)
+		const broadcastedVersions = buildBroadcastedElementVersions(originalElements)
+		const updatedElements = originalElements.map((element, index) =>
+			index === 17
+				? makeElement(element.id, element.version + 1)
+				: element,
+		)
+
+		const incrementalElements = getIncrementalSceneElements(
+			updatedElements,
+			broadcastedVersions,
+		)
+
+		expect(incrementalElements).toHaveLength(1)
+		expect(incrementalElements[0]).toMatchObject({
+			id: 'element-18',
+			version: 2,
+		})
+	})
+
+	it('selects newly added elements without resending the full scene', () => {
+		const originalElements = Array.from({ length: 45 }, (_value, index) =>
+			makeElement(`element-${index + 1}`),
+		)
+		const broadcastedVersions = buildBroadcastedElementVersions(originalElements)
+		const updatedElements = [
+			...originalElements,
+			makeElement('element-46'),
+		]
+
+		const incrementalElements = getIncrementalSceneElements(
+			updatedElements,
+			broadcastedVersions,
+		)
+
+		expect(incrementalElements).toHaveLength(1)
+		expect(incrementalElements[0]).toMatchObject({
+			id: 'element-46',
+			version: 1,
+		})
+	})
+
+	it('merges remote versions without downgrading already synced elements', () => {
+		const syncedVersions = {
+			E1: 5,
+			E2: 3,
+		}
+
+		const mergedVersions = mergeBroadcastedElementVersions(
+			syncedVersions,
+			[
+				makeElement('E1', 4),
+				makeElement('E2', 6),
+			],
+		)
+
+		expect(mergedVersions).toEqual({
+			E1: 5,
+			E2: 6,
+		})
+	})
+
+	it('skips scene broadcast and advances sync markers after remote-only changes', () => {
+		const elements = [
+			makeElement('E1', 4, 444),
+			makeElement('E2', 5, 555),
+		]
+		const plan = planIncrementalSceneSync({
+			elements,
+			broadcastedElementVersions: {
+				E1: 4,
+				E2: 5,
+			},
+			lastSceneHash: 123,
+		})
+
+		expect(plan).toEqual({
+			type: 'advance',
+			sceneHash: computeElementVersionHash(elements),
+			broadcastedElementVersions: {
+				E1: 4,
+				E2: 5,
+			},
+		})
+	})
+
+	it('broadcasts only unsent local edits after remote versions are merged', () => {
+		const lastSentElements = [
+			makeElement('E1', 3, 101),
+			makeElement('E2', 5, 202),
+		]
+		const reconciledElements = [
+			makeElement('E1', 4, 303),
+			makeElement('E2', 6, 404),
+		]
+		const syncedVersions = mergeBroadcastedElementVersions(
+			buildBroadcastedElementVersions(lastSentElements),
+			[makeElement('E1', 4, 303)],
+		)
+
+		const plan = planIncrementalSceneSync({
+			elements: reconciledElements,
+			broadcastedElementVersions: syncedVersions,
+			lastSceneHash: 505,
+		})
+
+		expect(plan).toEqual({
+			type: 'broadcast',
+			sceneHash: computeElementVersionHash(reconciledElements),
+			sceneElements: [makeElement('E2', 6, 404)],
+			broadcastedElementVersions: {
+				E2: 6,
+			},
+		})
+	})
+})

--- a/tests/integration/tableLocking.spec.mjs
+++ b/tests/integration/tableLocking.spec.mjs
@@ -4,9 +4,33 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { isLockExpired, setLockOnElement, tryAcquireLock, releaseLock } from '../../src/utils/tableLocking.ts'
-import * as auth from '@nextcloud/auth'
-import * as dialogs from '@nextcloud/dialogs'
+
+vi.mock('@nextcloud/excalidraw', () => ({
+	newElementWith: vi.fn((element, updates = {}, force = false) => {
+		let didChange = false
+		for (const [key, value] of Object.entries(updates)) {
+			if (typeof value === 'undefined') {
+				continue
+			}
+			if (element[key] === value && (typeof value !== 'object' || value === null)) {
+				continue
+			}
+			didChange = true
+		}
+
+		if (!didChange && !force) {
+			return element
+		}
+
+		return {
+			...element,
+			...updates,
+			updated: 1,
+			version: (element.version ?? 0) + 1,
+			versionNonce: 1,
+		}
+	}),
+}))
 
 // Mock the Nextcloud modules
 vi.mock('@nextcloud/auth', () => ({
@@ -19,6 +43,10 @@ vi.mock('@nextcloud/auth', () => ({
 vi.mock('@nextcloud/dialogs', () => ({
 	showError: vi.fn(),
 }))
+
+const { isLockExpired, setLockOnElement, tryAcquireLock, releaseLock } = await import('../../src/utils/tableLocking.ts')
+const auth = await import('@nextcloud/auth')
+const dialogs = await import('@nextcloud/dialogs')
 
 describe('tableLocking utilities', () => {
 	describe('isLockExpired', () => {

--- a/tests/integration/useSyncScheduling.spec.tsx
+++ b/tests/integration/useSyncScheduling.spec.tsx
@@ -1,0 +1,367 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+// @vitest-environment jsdom
+
+import { createElement, useEffect } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react-dom/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useSync } from '../../src/hooks/useSync'
+import { useCollaborationStore } from '../../src/stores/useCollaborationStore'
+import { useExcalidrawStore } from '../../src/stores/useExcalidrawStore'
+import { useSyncStore } from '../../src/stores/useSyncStore'
+import { useWhiteboardConfigStore } from '../../src/stores/useWhiteboardConfigStore'
+
+vi.mock('@nextcloud/router', () => ({
+	generateUrl: (path: string) => `/index.php/${path}`,
+}))
+
+vi.mock('@nextcloud/excalidraw', () => ({
+	hashString: () => 1,
+}))
+
+vi.mock('../../src/utils/logger', () => ({
+	default: {
+		debug: vi.fn(),
+		error: vi.fn(),
+		warn: vi.fn(),
+	},
+}))
+
+vi.mock('../../src/utils/sanitizeAppState', () => ({
+	sanitizeAppStateForSync: (appState: unknown) => appState ?? {},
+}))
+
+vi.mock('../../src/utils/syncSceneData', () => ({
+	buildBroadcastedElementVersions: (elements: Array<{ id: string, version: number }>) => (
+		elements.reduce<Record<string, number>>((versions, element) => {
+			versions[element.id] = element.version
+			return versions
+		}, {})
+	),
+	planIncrementalSceneSync: ({ elements }: { elements: Array<{ id: string, version: number }> }) => {
+		if (elements.length === 0) {
+			return { type: 'noop' }
+		}
+
+		return {
+			type: 'broadcast',
+			sceneHash: 1,
+			sceneElements: elements,
+			broadcastedElementVersions: elements.reduce<Record<string, number>>((versions, element) => {
+				versions[element.id] = element.version
+				return versions
+			}, {}),
+		}
+	},
+}))
+
+vi.mock('../../src/stores/useWhiteboardConfigStore', async () => {
+	const { create } = await import('zustand')
+	return {
+		useWhiteboardConfigStore: create(() => ({
+			fileId: 42,
+			isReadOnly: false,
+		})),
+	}
+})
+
+vi.mock('../../src/stores/useExcalidrawStore', async () => {
+	const { create } = await import('zustand')
+	return {
+		useExcalidrawStore: create(() => ({
+			excalidrawAPI: null,
+			setExcalidrawAPI: () => {},
+			resetExcalidrawAPI: () => {},
+		})),
+	}
+})
+
+vi.mock('../../src/stores/useSyncStore', async () => {
+	const { create } = await import('zustand')
+	return {
+		useSyncStore: create(() => ({
+			worker: null,
+			isWorkerReady: false,
+			initializeWorker: () => null,
+			terminateWorker: () => {},
+			setWorker: () => {},
+			setIsWorkerReady: () => {},
+		})),
+		logSyncResult: () => {},
+	}
+})
+
+vi.mock('../../src/stores/useJwtStore', async () => {
+	const { create } = await import('zustand')
+	return {
+		useJWTStore: create(() => ({
+			tokens: { 42: 'jwt-token' },
+			getJWT: async () => 'jwt-token',
+			parseJwt: () => ({ userid: 'test-user' }),
+		})),
+	}
+})
+
+vi.mock('../../src/stores/useCollaborationStore', async () => {
+	const { create } = await import('zustand')
+	const useCollaborationStore = create((set) => ({
+		status: 'online',
+		socket: null,
+		isDedicatedSyncer: true,
+		lastSceneHash: null,
+		broadcastedElementVersions: {},
+		setStatus: (status: string) => set({ status }),
+		setSocket: (socket: unknown) => set({ socket }),
+		setDedicatedSyncer: (isDedicatedSyncer: boolean) => set({ isDedicatedSyncer }),
+		setIsInRoom: () => {},
+		setLastSceneHash: (lastSceneHash: number | null) => set({ lastSceneHash }),
+		replaceBroadcastedElementVersions: (broadcastedElementVersions: Record<string, number>) => set({ broadcastedElementVersions }),
+		mergeBroadcastedElementVersions: () => {},
+		resetSceneSyncState: () => set({ lastSceneHash: null, broadcastedElementVersions: {} }),
+		authError: {},
+		incrementAuthFailure: () => {},
+		clearAuthError: () => {},
+		resetStore: () => {},
+		presenterId: null,
+		isPresentationMode: false,
+		isPresenting: false,
+		presentationStartTime: null,
+		autoFollowPresenter: false,
+		setPresentationState: () => {},
+		setAutoFollowPresenter: () => {},
+		followedUserId: null,
+		votings: [],
+		addVoting: () => {},
+		updateVoting: () => {},
+		setVotings: () => {},
+	}))
+
+	return { useCollaborationStore }
+})
+
+type HookHandlers = ReturnType<typeof useSync>
+
+type MockElement = {
+	id: string
+	type: string
+	version: number
+	text?: string
+	isDeleted?: boolean
+}
+
+type MockWorkerMessage = {
+	type: string
+	elements?: MockElement[]
+}
+
+function HookHarness({ onReady }: { onReady: (handlers: HookHandlers) => void }) {
+	const handlers = useSync()
+
+	useEffect(() => {
+		onReady(handlers)
+	}, [handlers, onReady])
+
+	return null
+}
+
+const appState = {
+	scrollX: 0,
+	scrollY: 0,
+	zoom: { value: 1 },
+	selectedElementIds: {},
+}
+
+const decodeScenePayload = (payload: Uint8Array<ArrayBuffer>) => {
+	return JSON.parse(new TextDecoder().decode(payload))
+}
+
+describe('useSync scheduling', () => {
+	let container: HTMLDivElement
+	let root: Root
+	let handlers: HookHandlers
+	let sceneElements: MockElement[]
+	let files: Record<string, never>
+	let worker: { postMessage: ReturnType<typeof vi.fn> }
+	let socket: { emit: ReturnType<typeof vi.fn> }
+
+	beforeEach(() => {
+		vi.useFakeTimers()
+		sceneElements = []
+		files = {}
+		worker = { postMessage: vi.fn() }
+		socket = { emit: vi.fn() }
+
+		useWhiteboardConfigStore.setState({
+			fileId: 42,
+			isReadOnly: false,
+		})
+
+		useExcalidrawStore.setState({
+			excalidrawAPI: {
+				getSceneElementsIncludingDeleted: () => sceneElements,
+				getAppState: () => appState,
+				getFiles: () => files,
+			},
+		})
+
+		useSyncStore.setState({
+			worker,
+			isWorkerReady: true,
+			initializeWorker: () => null,
+			terminateWorker: () => {},
+		})
+
+		useCollaborationStore.setState({
+			status: 'online',
+			socket,
+			isDedicatedSyncer: true,
+			lastSceneHash: null,
+			broadcastedElementVersions: {},
+		})
+
+		container = document.createElement('div')
+		document.body.appendChild(container)
+		root = createRoot(container)
+
+		act(() => {
+			root.render(createElement(HookHarness, {
+				onReady: (nextHandlers: HookHandlers) => {
+					handlers = nextHandlers
+				},
+			}))
+		})
+	})
+
+	afterEach(() => {
+		useCollaborationStore.setState({
+			isDedicatedSyncer: false,
+		})
+
+		act(() => {
+			root.unmount()
+		})
+		container.remove()
+		vi.useRealTimers()
+		vi.clearAllMocks()
+	})
+
+	it('sends the first server and websocket sync on the trailing edge with the settled scene', async () => {
+		act(() => {
+			handlers.onChange([], appState as never, files as never)
+		})
+
+		const syncToServerMessages = worker.postMessage.mock.calls.filter(([message]: [MockWorkerMessage]) => message.type === 'SYNC_TO_SERVER')
+		expect(syncToServerMessages).toHaveLength(0)
+		expect(socket.emit).toHaveBeenCalledTimes(0)
+
+		sceneElements = [{
+			id: 'text-1',
+			type: 'text',
+			version: 1,
+			text: 'Live text',
+		}]
+
+		await vi.advanceTimersByTimeAsync(499)
+		expect(socket.emit).toHaveBeenCalledTimes(0)
+
+		await vi.advanceTimersByTimeAsync(1)
+		expect(socket.emit).toHaveBeenCalledTimes(1)
+		expect(socket.emit.mock.calls[0][0]).toBe('server-broadcast')
+		expect(decodeScenePayload(socket.emit.mock.calls[0][2] as Uint8Array<ArrayBuffer>)).toMatchObject({
+			type: 'SCENE_UPDATE',
+			payload: {
+				elements: [{
+					id: 'text-1',
+					text: 'Live text',
+				}],
+			},
+		})
+
+		await vi.advanceTimersByTimeAsync(9499)
+		expect(worker.postMessage.mock.calls.filter(([message]: [MockWorkerMessage]) => message.type === 'SYNC_TO_SERVER')).toHaveLength(0)
+
+		await vi.advanceTimersByTimeAsync(1)
+		const serverMessages = worker.postMessage.mock.calls
+			.map(([message]: [MockWorkerMessage]) => message)
+			.filter((message) => message.type === 'SYNC_TO_SERVER')
+
+		expect(serverMessages).toHaveLength(1)
+		expect(serverMessages[0].elements).toEqual([{
+			id: 'text-1',
+			type: 'text',
+			version: 1,
+			text: 'Live text',
+		}])
+	})
+
+	it('reschedules pending server and websocket syncs after readiness transitions instead of flushing immediately', async () => {
+		useSyncStore.setState({
+			worker,
+			isWorkerReady: false,
+		})
+		useCollaborationStore.setState({
+			status: 'connecting',
+			socket,
+			isDedicatedSyncer: false,
+			lastSceneHash: null,
+			broadcastedElementVersions: {},
+		})
+
+		act(() => {
+			handlers.onChange([], appState as never, files as never)
+		})
+
+		sceneElements = [{
+			id: 'text-2',
+			type: 'text',
+			version: 2,
+			text: 'Ready later',
+		}]
+
+		act(() => {
+			useSyncStore.setState({
+				worker,
+				isWorkerReady: true,
+			})
+			useCollaborationStore.setState({
+				status: 'online',
+				socket,
+				isDedicatedSyncer: true,
+				lastSceneHash: null,
+				broadcastedElementVersions: {},
+			})
+		})
+
+		expect(socket.emit).toHaveBeenCalledTimes(0)
+		expect(worker.postMessage.mock.calls.filter(([message]: [MockWorkerMessage]) => message.type === 'SYNC_TO_SERVER')).toHaveLength(0)
+
+		await vi.advanceTimersByTimeAsync(500)
+		expect(socket.emit).toHaveBeenCalledTimes(1)
+		expect(decodeScenePayload(socket.emit.mock.calls[0][2] as Uint8Array<ArrayBuffer>)).toMatchObject({
+			type: 'SCENE_UPDATE',
+			payload: {
+				elements: [{
+					id: 'text-2',
+					text: 'Ready later',
+				}],
+			},
+		})
+
+		await vi.advanceTimersByTimeAsync(9500)
+		const serverMessages = worker.postMessage.mock.calls
+			.map(([message]: [MockWorkerMessage]) => message)
+			.filter((message) => message.type === 'SYNC_TO_SERVER')
+
+		expect(serverMessages).toHaveLength(1)
+		expect(serverMessages[0].elements).toEqual([{
+			id: 'text-2',
+			type: 'text',
+			version: 2,
+			text: 'Ready later',
+		}])
+	})
+})

--- a/tools/benchmarks/runIncrementalSyncBenchmark.mjs
+++ b/tools/benchmarks/runIncrementalSyncBenchmark.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { spawn } from 'node:child_process'
+
+const knownScenarios = ['retro-board', 'planning-flow', 'media-review']
+const knownMutations = ['single-text-edit', 'selection-drag', 'mixed-session-burst']
+
+function printHelp() {
+	console.log(`Usage: npm run bench:incremental-sync -- [options]
+
+Options:
+  --scenario <name[,name]>    Scenario(s): ${knownScenarios.join(', ')}
+  --mutation <name[,name]>    Mutation(s): ${knownMutations.join(', ')}
+  --scale <n>                 Scale up the scene builders (default: 1)
+  --runs <n>                  Full-stack runs per case (default: 1)
+  --project <name>            Playwright project to use (default: chromium)
+  --headed                    Run the browser headed
+  --output-json <path>        Write machine-readable results to a JSON file
+  --help                      Show this message
+
+Examples:
+  npm run bench:incremental-sync
+  npm run bench:incremental-sync -- --scenario planning-flow --mutation selection-drag --runs 2
+  npm run bench:incremental-sync -- --scenario retro-board,media-review --scale 2 --output-json tools/benchmarks/incremental-sync-results.json
+
+This benchmark boots the Playwright Nextcloud test stack and measures actual
+scene bootstrap and incremental sync payloads through the real whiteboard app.`)
+}
+
+function readOption(args, flag) {
+	const index = args.indexOf(flag)
+	if (index === -1) {
+		return null
+	}
+	return args[index + 1] ?? null
+}
+
+const args = process.argv.slice(2)
+
+if (args.includes('--help')) {
+	printHelp()
+	process.exit(0)
+}
+
+const scenario = readOption(args, '--scenario')
+const mutation = readOption(args, '--mutation')
+const scale = readOption(args, '--scale')
+const runs = readOption(args, '--runs') ?? readOption(args, '--iterations')
+const project = readOption(args, '--project') || 'chromium'
+const outputJson = readOption(args, '--output-json')
+const headed = args.includes('--headed')
+
+const env = {
+	...process.env,
+	WHITEBOARD_INCREMENTAL_SYNC_BENCH: '1',
+	...(scenario ? { SYNC_BENCH_SCENARIOS: scenario } : {}),
+	...(mutation ? { SYNC_BENCH_MUTATIONS: mutation } : {}),
+	...(scale ? { SYNC_BENCH_SCALE: scale } : {}),
+	...(runs ? { SYNC_BENCH_RUNS: runs } : {}),
+	...(outputJson ? { SYNC_BENCH_OUTPUT_PATH: outputJson } : {}),
+}
+
+const child = spawn('npx', [
+	'playwright',
+	'test',
+	'playwright/bench/incremental-sync-benchmark.spec.ts',
+	'--config=playwright.config.ts',
+	'--project',
+	project,
+	'--workers=1',
+	'--reporter=line',
+	...(headed ? ['--headed'] : []),
+], {
+	env,
+	stdio: 'inherit',
+})
+
+child.on('exit', (code) => {
+	process.exit(code ?? 1)
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -37,7 +37,6 @@ const AppConfig = createAppConfig({
 					manualChunks: {
 						vendor: ['react', 'react-dom'],
 					},
-					// assetFileNames: 'js/[name]-[hash].[ext]',
 				},
 			},
 		},
@@ -46,6 +45,8 @@ const AppConfig = createAppConfig({
 			rollupOptions: {
 				output: {
 					entryFileNames: 'js/[name]-[hash].js',
+					chunkFileNames: 'js/[name]-[hash].chunk.js',
+					assetFileNames: 'dist/[name]-[hash][extname]',
 				},
 			},
 		},

--- a/websocket_server/Services/RoomLifecycleService.js
+++ b/websocket_server/Services/RoomLifecycleService.js
@@ -161,16 +161,17 @@ export default class RoomLifecycleService {
 		}
 	}
 
-	async onDisconnecting(socket, rooms, { shuttingDown = false } = {}) {
+	async onDisconnecting(socket, rooms, { shuttingDown = false, socketData: initialSocketData = null } = {}) {
 		if (shuttingDown) {
 			return
 		}
+
+		const socketData = initialSocketData || await this.sessionStore.getSocketData(socket.id)
+		const userId = socketData?.user?.id
+		const userName = socketData?.user?.name || 'Unknown'
+
 		for (const roomID of rooms) {
 			if (roomID === socket.id) continue
-
-			const socketData = await this.sessionStore.getSocketData(socket.id)
-			const userId = socketData?.user?.id
-			const userName = socketData?.user?.name || 'Unknown'
 
 			console.log(`[${roomID}] User ${userName} disconnecting`)
 

--- a/websocket_server/Services/SocketService.js
+++ b/websocket_server/Services/SocketService.js
@@ -501,6 +501,7 @@ export default class SocketService {
 		const events = {
 			'join-room': this.joinRoomHandler,
 			'server-broadcast': this.serverBroadcastHandler,
+			'server-direct-broadcast': this.serverDirectBroadcastHandler,
 			'server-volatile-broadcast': this.serverVolatileBroadcastHandler,
 			'image-get': this.imageGetHandler,
 			'check-recording-availability': this.checkRecordingAvailabilityHandler,
@@ -536,8 +537,10 @@ export default class SocketService {
 			const rooms = Array.from(socket.rooms).filter(
 				(room) => room !== socket.id,
 			)
-			this.safeSocketHandler(socket, () =>
-				this.disconnectingHandler(socket, rooms),
+			this.safeSocketHandler(socket, async () => {
+				const socketData = await this.sessionStore.getSocketData(socket.id)
+				return this.disconnectingHandler(socket, rooms, socketData)
+			},
 			)
 		})
 	}
@@ -552,6 +555,10 @@ export default class SocketService {
 
 	async serverBroadcastHandler(socket, roomID, encryptedData, iv) {
 		return this.viewportController.serverBroadcast(socket, roomID, encryptedData, iv)
+	}
+
+	async serverDirectBroadcastHandler(socket, roomID, targetSocketId, encryptedData, iv) {
+		return this.viewportController.serverDirectBroadcast(socket, roomID, targetSocketId, encryptedData, iv)
 	}
 
 	async serverVolatileBroadcastHandler(socket, roomID, encryptedData) {
@@ -582,14 +589,17 @@ export default class SocketService {
 		}
 	}
 
-	async disconnectingHandler(socket, rooms) {
+	async disconnectingHandler(socket, rooms, socketData) {
 		if (this.shuttingDown) {
 			return
 		}
 
-		await this.stopRecordingOnDisconnect(socket, rooms)
+		await this.stopRecordingOnDisconnect(socket, rooms, socketData)
 
-		return this.roomLifecycleController.onDisconnecting(socket, rooms, { shuttingDown: this.shuttingDown })
+		return this.roomLifecycleController.onDisconnecting(socket, rooms, {
+			shuttingDown: this.shuttingDown,
+			socketData,
+		})
 	}
 
 	cancelPendingRecordingStop(roomID, userId) {
@@ -700,8 +710,8 @@ export default class SocketService {
 		})
 	}
 
-	async stopRecordingOnDisconnect(socket, rooms) {
-		const socketData = await this.sessionStore.getSocketData(socket.id)
+	async stopRecordingOnDisconnect(socket, rooms, initialSocketData = null) {
+		const socketData = initialSocketData || await this.sessionStore.getSocketData(socket.id)
 		if (!socketData?.user?.id) {
 			return
 		}

--- a/websocket_server/Services/ViewportService.js
+++ b/websocket_server/Services/ViewportService.js
@@ -24,6 +24,20 @@ export default class ViewportService {
 		socket.broadcast.to(roomID).emit('client-broadcast', encryptedData, iv)
 	}
 
+	async serverDirectBroadcast(socket, roomID, targetSocketId, encryptedData, iv) {
+		const isReadOnly = await this.sessionStore.isReadOnly(socket.id)
+		if (!socket.rooms.has(roomID) || isReadOnly) return
+
+		const targetSockets = await this.io.in(targetSocketId).fetchSockets()
+		const targetSocket = targetSockets[0]
+
+		if (!targetSocket || !targetSocket.rooms.has(roomID)) {
+			return
+		}
+
+		this.io.to(targetSocketId).emit('client-broadcast', encryptedData, iv)
+	}
+
 	async serverVolatileBroadcast(socket, roomID, encryptedData) {
 		if (!socket.rooms.has(roomID)) return
 


### PR DESCRIPTION
## Purpose

Moves the benchmark runner and deep wire-capture harness out of #1081 so the main PR stays focused on shipping behavior plus minimal proof tests.

## Includes

- `npm run bench:incremental-sync` runner and benchmark script
- full-stack Playwright benchmark spec plus fixtures/hooks
- deeper collaboration wire-capture E2E assertions
- extra test-only observability hooks needed by the benchmark harness

## Stack

- base: #1081 (`feat/incremetal-sync-improvements`)
- review this after the main incremental-sync PR
