### PR TITLE
Security: Overly Permissive Content Security Policy

### DIFF
--- a/lib/Listener/AddContentSecurityPolicyListener.php
+++ b/lib/Listener/AddContentSecurityPolicyListener.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace OCA\Whiteboard\Listener;
 
 use OCP\AppFramework\Http\EmptyContentSecurityPolicy;
+use OCP\AppFramework\IAppContainer;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\IRequest;
@@ -17,6 +18,7 @@ use OCP\Security\CSP\AddContentSecurityPolicyEvent;
 class AddContentSecurityPolicyListener implements IEventListener {
 	public function __construct(
 		private IRequest $request,
+		private IAppContainer $appContainer,
 	) {
 	}
 
@@ -28,9 +30,12 @@ class AddContentSecurityPolicyListener implements IEventListener {
 
 		$policy = new EmptyContentSecurityPolicy();
 
-		$policy->addAllowedConnectDomain('*');
-		$policy->addAllowedWorkerSrcDomain('*');
-		$policy->addAllowedFontDomain('*');
+		$serverUrl = $this->appContainer->getConfig()->getAppValue('whiteboard', 'collabServerUrl', '');
+		if ($serverUrl !== '') {
+			$policy->addAllowedConnectDomain($serverUrl);
+			$policy->addAllowedWorkerSrcDomain($serverUrl);
+			$policy->addAllowedFontDomain($serverUrl);
+		}
 
 		$event->addPolicy($policy);
 	}


### PR DESCRIPTION
## Summary

Security: Overly Permissive Content Security Policy

## Problem

**Severity**: `High` | **File**: `lib/Listener/AddContentSecurityPolicyListener.php:L29`

The CSP in AddContentSecurityPolicyListener.php allows connections to all domains ('*') for connect-src, worker-src, and font-src. This enables the whiteboard to connect to arbitrary external servers, potentially exfiltrating data or receiving malicious content.

## Solution

Replace wildcard '*' with specific allowed domains for the collab backend. If the backend URL is configurable, use that specific domain instead of '*'.

## Changes

- `lib/Listener/AddContentSecurityPolicyListener.php` (modified)