### PR TITLE
feat: add DirectEditing for mobile app support

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -16,12 +16,14 @@ use OCA\Whiteboard\Listener\AddContentSecurityPolicyListener;
 use OCA\Whiteboard\Listener\BeforeTemplateRenderedListener;
 use OCA\Whiteboard\Listener\LoadTextEditorListener;
 use OCA\Whiteboard\Listener\LoadViewerListener;
+use OCA\Whiteboard\Listener\RegisterDirectEditorListener;
 use OCA\Whiteboard\Listener\RegisterTemplateCreatorListener;
 use OCA\Whiteboard\Settings\SetupCheck;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
+use OCP\DirectEditing\RegisterDirectEditorEvent;
 use OCP\Files\Template\ITemplateManager;
 use OCP\Files\Template\RegisterTemplateCreatorEvent;
 use OCP\IL10N;
@@ -48,6 +50,7 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(LoadViewer::class, LoadTextEditorListener::class);
 		$context->registerEventListener(RegisterTemplateCreatorEvent::class, RegisterTemplateCreatorListener::class);
 		$context->registerEventListener(BeforeTemplateRenderedEvent::class, BeforeTemplateRenderedListener::class);
+		$context->registerEventListener(RegisterDirectEditorEvent::class, RegisterDirectEditorListener::class);
 		$context->registerSetupCheck(SetupCheck::class);
 	}
 

--- a/lib/DirectEditing/WhiteboardCreator.php
+++ b/lib/DirectEditing/WhiteboardCreator.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Whiteboard\DirectEditing;
+
+use OCP\DirectEditing\ACreateEmpty;
+use OCP\IL10N;
+
+class WhiteboardCreator extends ACreateEmpty {
+
+	public const CREATOR_ID = 'whiteboard';
+
+	public function __construct(
+		private IL10N $l10n,
+	) {
+	}
+
+	#[\Override]
+	public function getId(): string {
+		return self::CREATOR_ID;
+	}
+
+	#[\Override]
+	public function getName(): string {
+		return $this->l10n->t('whiteboard');
+	}
+
+	#[\Override]
+	public function getExtension(): string {
+		return 'whiteboard';
+	}
+
+	#[\Override]
+	public function getMimetype(): string {
+		return 'application/vnd.excalidraw+json';
+	}
+}

--- a/lib/DirectEditing/WhiteboardCreator.php
+++ b/lib/DirectEditing/WhiteboardCreator.php
@@ -28,7 +28,7 @@ class WhiteboardCreator extends ACreateEmpty {
 
 	#[\Override]
 	public function getName(): string {
-		return $this->l10n->t('whiteboard');
+		return $this->l10n->t('Whiteboard');
 	}
 
 	#[\Override]

--- a/lib/DirectEditing/WhiteboardDirectEditor.php
+++ b/lib/DirectEditing/WhiteboardDirectEditor.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Whiteboard\DirectEditing;
+
+use OCA\Whiteboard\AppInfo\Application;
+use OCA\Whiteboard\Exception\UnauthorizedException;
+use OCA\Whiteboard\Service\Authentication\AuthenticateUserServiceFactory;
+use OCA\Whiteboard\Service\ConfigService;
+use OCA\Whiteboard\Service\JWTService;
+use OCP\AppFramework\Http\NotFoundResponse;
+use OCP\AppFramework\Http\Response;
+use OCP\AppFramework\Http\TemplateResponse;
+use OCP\AppFramework\Services\IInitialState;
+use OCP\DirectEditing\IEditor;
+use OCP\DirectEditing\IToken;
+use OCP\Files\InvalidPathException;
+use OCP\Files\NotFoundException;
+use OCP\IL10N;
+use OCP\Util;
+
+class WhiteboardDirectEditor implements IEditor {
+
+	/** @psalm-suppress PossiblyUnusedMethod */
+	public function __construct(
+		private IL10N $l10n,
+		private IInitialState $initialState,
+		private ConfigService $configService,
+		private JWTService $jwtService,
+		private AuthenticateUserServiceFactory $authenticateUserServiceFactory,
+	) {
+	}
+
+	#[\Override]
+	public function getId(): string {
+		return Application::APP_ID;
+	}
+
+	#[\Override]
+	public function getName(): string {
+		return $this->l10n->t('Whiteboard');
+	}
+
+	#[\Override]
+	public function getMimetypes(): array {
+		return [
+			'application/vnd.excalidraw+json',
+		];
+	}
+
+	#[\Override]
+	public function getMimetypesOptional(): array {
+		return [];
+	}
+
+	#[\Override]
+	public function getCreators(): array {
+		return [
+			new WhiteboardCreator($this->l10n),
+		];
+	}
+
+	#[\Override]
+	public function isSecure(): bool {
+		return false;
+	}
+
+	#[\Override]
+	public function open(IToken $token): Response {
+		$token->useTokenScope();
+
+		try {
+			$file = $token->getFile();
+
+			Util::addScript('whiteboard', 'whiteboard-main');
+			Util::addStyle('whiteboard', 'whiteboard-main');
+
+			$user = $this->authenticateUserServiceFactory->create(null)->authenticate();
+			$jwt = $this->jwtService->generateJWT($user, $file, false);
+
+			$this->initialState->provideInitialState('file_id', $file->getId());
+			$this->initialState->provideInitialState('directEditing', true);
+			$this->initialState->provideInitialState('jwt', $jwt);
+			$this->initialState->provideInitialState('collabBackendUrl', $this->configService->getCollabBackendUrl());
+
+			return new TemplateResponse(Application::APP_ID, 'directEditing', [], 'base');
+		} catch (InvalidPathException|NotFoundException|UnauthorizedException) {
+			return new NotFoundResponse();
+		}
+	}
+}

--- a/lib/DirectEditing/WhiteboardDirectEditor.php
+++ b/lib/DirectEditing/WhiteboardDirectEditor.php
@@ -80,6 +80,7 @@ class WhiteboardDirectEditor implements IEditor {
 
 			Util::addScript('whiteboard', 'whiteboard-main');
 			Util::addStyle('whiteboard', 'whiteboard-main');
+			Util::addScript('text', 'text-editor');
 
 			$user = $this->authenticateUserServiceFactory->create(null)->authenticate();
 			$jwt = $this->jwtService->generateJWT($user, $file, false);

--- a/lib/Listener/RegisterDirectEditorListener.php
+++ b/lib/Listener/RegisterDirectEditorListener.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Whiteboard\Listener;
+
+use OCA\Whiteboard\DirectEditing\WhiteboardDirectEditor;
+use OCP\DirectEditing\RegisterDirectEditorEvent;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+
+/** @template-implements IEventListener<Event|RegisterDirectEditorEvent> */
+/**
+ * @psalm-suppress UndefinedClass
+ * @psalm-suppress MissingTemplateParam
+ */
+final class RegisterDirectEditorListener implements IEventListener {
+
+	/** @psalm-suppress PossiblyUnusedMethod */
+	public function __construct(
+		private WhiteboardDirectEditor $editor,
+	) {
+	}
+
+	#[\Override]
+	public function handle(Event $event): void {
+		if (!$event instanceof RegisterDirectEditorEvent) {
+			return;
+		}
+		$event->register($this->editor);
+	}
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -54,6 +54,7 @@ import { VotingSidebar } from './components/VotingSidebar'
 import { useVoting } from './hooks/useVoting'
 import { useContextMenuFilter } from './hooks/useContextMenuFilter'
 import { useDisableExternalLibraries } from './hooks/useDisableExternalLibraries'
+import { callMobileMessage } from './utils/mobileInterface'
 
 const Excalidraw = memo(ExcalidrawComponent)
 
@@ -286,6 +287,12 @@ export default function App({
 
 	// Use the board data manager hook
 	const { saveOnUnmount, isLoading } = useBoardDataManager()
+
+	useEffect(() => {
+		if (!isLoading && loadState('whiteboard', 'directEditing', false)) {
+			callMobileMessage('loaded')
+		}
+	}, [isLoading])
 
 	// Effect to handle fileId changes - cleanup previous board data
 	useEffect(() => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,7 @@ import {
 	renderWhiteboardView,
 } from './utils/renderWhiteboardView'
 import type { WhiteboardRootHandle } from './utils/renderWhiteboardView'
+import { callMobileMessage } from './utils/mobileInterface'
 
 declare global {
 	interface Window {
@@ -38,6 +39,12 @@ type PublicShareContext = {
 	sharingToken: string | null
 }
 
+type DirectEditingContext = {
+	fileId: number
+	collabBackendUrl: string
+	jwt: string
+}
+
 type ViewerContext = {
 	collabBackendUrl: string
 	resolveSharingToken: () => string | null
@@ -46,6 +53,7 @@ type ViewerContext = {
 type RuntimeDescriptor =
 	| { type: 'recording'; context: RecordingContext }
 	| { type: 'public-share'; context: PublicShareContext }
+	| { type: 'direct-editing'; context: DirectEditingContext }
 	| { type: 'viewer'; context: ViewerContext }
 
 const VIEWER_REGISTRATION_ATTEMPTS = 3
@@ -60,6 +68,9 @@ const bootstrapWhiteboardRuntime = (): void => {
 		return
 	case 'public-share':
 		runPublicShareRuntime(runtime.context)
+		return
+	case 'direct-editing':
+		runDirectEditingRuntime(runtime.context)
 		return
 	case 'viewer':
 	default:
@@ -76,6 +87,17 @@ const detectRuntime = (): RuntimeDescriptor => {
 	if (loadState('whiteboard', 'isRecording', false)) {
 		return {
 			type: 'recording',
+			context: {
+				fileId,
+				collabBackendUrl,
+				jwt: loadState('whiteboard', 'jwt', ''),
+			},
+		}
+	}
+
+	if (loadState('whiteboard', 'directEditing', false)) {
+		return {
+			type: 'direct-editing',
 			context: {
 				fileId,
 				collabBackendUrl,
@@ -113,6 +135,30 @@ function runRecordingRuntime(context: RecordingContext): void {
 		const whiteboardElement = createWhiteboardElement()
 		whiteboardElement.classList.add('recording')
 		document.body.appendChild(whiteboardElement)
+
+		renderWhiteboardView(whiteboardElement, {
+			fileId: context.fileId,
+			isEmbedded: false,
+			fileName: '',
+			publicSharingToken: null,
+			collabBackendUrl: context.collabBackendUrl,
+			versionSource: null,
+			fileVersion: null,
+		})
+	})
+}
+
+function runDirectEditingRuntime(context: DirectEditingContext): void {
+	runWhenDomReady(async () => {
+		await primeRecordingJwt(context.fileId, context.jwt)
+
+		const whiteboardElement = document.getElementById('whiteboard-app')
+		if (!whiteboardElement) {
+			logger.error('Direct editing mount element not found')
+			return
+		}
+
+		callMobileMessage('loading')
 
 		renderWhiteboardView(whiteboardElement, {
 			fileId: context.fileId,

--- a/src/utils/mobileInterface.ts
+++ b/src/utils/mobileInterface.ts
@@ -1,0 +1,51 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare global {
+	interface Window {
+		DirectEditingMobileInterface?: {
+			[key: string]: (arg?: string) => void
+		}
+		webkit?: {
+			messageHandlers?: {
+				DirectEditingMobileInterface?: {
+					postMessage: (message: unknown) => void
+				}
+			}
+		}
+	}
+}
+
+export function callMobileMessage(messageName: string, attributes?: unknown): void {
+	let message: unknown = messageName
+	if (typeof attributes !== 'undefined') {
+		message = {
+			MessageName: messageName,
+			Values: attributes,
+		}
+	}
+
+	let attributesString: string | null = null
+	try {
+		attributesString = JSON.stringify(attributes)
+	} catch {
+		attributesString = null
+	}
+
+	if (window.DirectEditingMobileInterface
+		&& typeof window.DirectEditingMobileInterface[messageName] === 'function') {
+		if (attributesString === null || typeof attributesString === 'undefined') {
+			window.DirectEditingMobileInterface[messageName]()
+		} else {
+			window.DirectEditingMobileInterface[messageName](attributesString)
+		}
+	}
+
+	if (window.webkit?.messageHandlers?.DirectEditingMobileInterface) {
+		window.webkit.messageHandlers.DirectEditingMobileInterface.postMessage(message)
+	}
+
+	window.postMessage(message)
+}

--- a/templates/directEditing.php
+++ b/templates/directEditing.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+?>
+
+<style>
+    body {
+        position: fixed;
+        background-color: var(--color-main-background);
+    }
+
+    #whiteboard-app {
+        width: 100%;
+        height: 100%;
+        position: fixed;
+    }
+
+    #body-public footer {
+        position: static;
+        left: auto;
+        bottom: auto;
+        transform: none;
+        width: auto;
+        max-width: none;
+    }
+</style>
+
+<div id="whiteboard-app" class="whiteboard"></div>


### PR DESCRIPTION
Implements `DirectEditing` for whiteboard, allowing `.whiteboard` files to be opened directly from the Nextcloud mobile apps.

**Note:** This PR focuses on the `DirectEditing` integration and does not include any UI polishing for mobile. Those can be addressed as follow-up.


Android: https://github.com/nextcloud/android/pull/16998
iOS: https://github.com/nextcloud/ios/pull/4101