### PR TITLE
chore: add OCI standard labels to Dockerfile

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -40,6 +40,8 @@ jobs:
             echo "version_channel=daily" >> $GITHUB_OUTPUT
           fi
           echo "version=${{ github.sha }}" >> $GITHUB_OUTPUT
+          echo "version_ref=${{ github.event_name == 'release' && github.ref_name || github.sha }}" >> $GITHUB_OUTPUT
+          echo "created=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
           echo "platform=$(echo -n ${{ matrix.platform }} | sed 's/\//-/g')" >> $GITHUB_OUTPUT
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -62,6 +64,10 @@ jobs:
           push: true
           platforms: ${{ matrix.platform }}
           provenance: false
+          build-args: |
+            VERSION=${{ steps.vars.outputs.version_ref }}
+            REVISION=${{ github.sha }}
+            CREATED=${{ steps.vars.outputs.created }}
           tags: |
             ${{ env.GHCR_REPO}}:${{ steps.vars.outputs.version }}-${{ steps.vars.outputs.platform }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,18 @@ RUN apk add --no-cache \
 COPY --from=build --chown=nobody:nobody /app /app
 USER nobody
 EXPOSE 3002
+ARG VERSION
+ARG REVISION
+ARG CREATED
+LABEL org.opencontainers.image.title="Nextcloud Whiteboard" \
+      org.opencontainers.image.description="Official whiteboard app for Nextcloud with real-time collaboration" \
+      org.opencontainers.image.url="https://github.com/nextcloud/whiteboard" \
+      org.opencontainers.image.source="https://github.com/nextcloud/whiteboard" \
+      org.opencontainers.image.vendor="Nextcloud GmbH" \
+      org.opencontainers.image.licenses="AGPL-3.0-or-later" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.revision="${REVISION}" \
+      org.opencontainers.image.created="${CREATED}"
 ENTRYPOINT ["npm", "run", "server:start"]
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
   CMD node -e "require('http').get('http://localhost:3002', (res) => { process.exit(res.statusCode === 200 ? 0 : 1) })"


### PR DESCRIPTION
## Context

Add [OCI (Open Container Initiative)](https://github.com/opencontainers/image-spec/blob/main/annotations.md) standard labels to the `Dockerfile` for better image metadata and container registry compatibility.

## Type

Improvement — metadata only, no functional changes.

## Labels Added

| Label | Value | Source |
|-------|-------|--------|
| `org.opencontainers.image.title` | `Nextcloud Whiteboard` | Static |
| `org.opencontainers.image.description` | `Official whiteboard app for Nextcloud with real-time collaboration` | Static |
| `org.opencontainers.image.url` | `https://github.com/nextcloud/whiteboard` | Static |
| `org.opencontainers.image.source` | `https://github.com/nextcloud/whiteboard` | Static |
| `org.opencontainers.image.vendor` | `Nextcloud GmbH` | Static |
| `org.opencontainers.image.licenses` | `AGPL-3.0-or-later` | Static |
| `org.opencontainers.image.version` | `${VERSION}` build arg | Dynamic (optional) |
| `org.opencontainers.image.revision` | `${REVISION}` build arg | Dynamic (optional) |
| `org.opencontainers.image.created` | `${CREATED}` build arg | Dynamic (optional) |

Static labels are always baked into the image. Dynamic labels (`version`, `revision`, `created`) are optional build-time args — they default to empty strings when not supplied, and can be passed via `docker build --build-arg VERSION=x.y.z --build-arg REVISION=$(git rev-parse HEAD) --build-arg CREATED=$(date -u +"%Y-%m-%dT%H:%M:%SZ")`.

## Benefits

- **Registry Compatibility**: GHCR, Docker Hub, and other registries display these labels in their UI
- **Dependency Bot Changelogs**: Renovate and Dependabot use `org.opencontainers.image.source` to link release notes in update PRs
- **Image Provenance**: Track source code and build information for security audits
- **Standardization**: Follow OCI best practices for container image metadata

## Changes

- `Dockerfile`: added 3 `ARG` instructions and 1 `LABEL` block (9 labels) in the final stage, after `EXPOSE` and before `ENTRYPOINT`/`HEALTHCHECK`

## References

- [OCI Image Spec - Annotations](https://github.com/opencontainers/image-spec/blob/main/annotations.md)
- [Renovate Docker datasource](https://docs.renovatebot.com/modules/datasource/docker/)
- [Docker - Manage tags and labels](https://docs.docker.com/build/ci/github-actions/manage-tags-labels/)