### PR TITLE
fix(fonts): copy fonts into the correct place

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,8 +7,6 @@ import { defineConfig, normalizePath } from 'vite'
 import { join, resolve } from 'path'
 import { viteStaticCopy } from 'vite-plugin-static-copy'
 
-const EXCALIDRAW_FONTS_DIR = normalizePath(resolve('node_modules/@nextcloud/excalidraw/dist/prod/fonts'))
-
 const AppConfig = createAppConfig({
 	main: resolve(join('src', 'main.ts')),
 	settings: resolve(join('src', 'admin.ts')),
@@ -70,8 +68,9 @@ const AppConfig = createAppConfig({
 			viteStaticCopy({
 				targets: [
 					{
-						src: EXCALIDRAW_FONTS_DIR,
+						src: normalizePath(resolve('node_modules/@nextcloud/excalidraw/dist/prod/fonts')),
 						dest: 'dist',
+						rename: {'stripBase': 5},
 					},
 				],
 			}),


### PR DESCRIPTION
In the plugin `vite-plugin-static-copy` starting from version 4, there's a major breaking change: the folder structure is now always preserved. Because of this, when copying the fonts into `dist`, it is under `node_modules/...` instead of `fonts`, which breaks font loading from the server.

This can be easily fixed with the new `rename` option.

Technically, this also fixes #1215, since loading fonts from the server is allowed by the CSP.