### PR TITLE
enh: use formatRelativeTime from @nextcloud/l10n for relative timestamps

### DIFF
--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -3,16 +3,10 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { t } from '@nextcloud/l10n'
+import { formatRelativeTime, t } from '@nextcloud/l10n'
 
 export function getRelativeTime(timestamp: number): string {
-	const seconds = Math.floor((Date.now() - timestamp) / 1000)
-	const minutes = Math.floor(seconds / 60)
-	const hours = Math.floor(minutes / 60)
-	const days = Math.floor(hours / 24)
-
-	if (seconds < 60) return t('whiteboard', 'Just now')
-	if (minutes < 60) return `${minutes} ${minutes === 1 ? t('whiteboard', 'minute ago') : t('whiteboard', 'minutes ago')}`
-	if (hours < 24) return `${hours} ${hours === 1 ? t('whiteboard', 'hour ago') : t('whiteboard', 'hours ago')}`
-	return `${days} days ago`
+	return formatRelativeTime(timestamp, {
+		ignoreSeconds: t('whiteboard', 'Just now'),
+	})
 }


### PR DESCRIPTION
Replaces the relative time logic in `getRelativeTime` with `formatRelativeTime` from `@nextcloud/l10n`.
For anything < 1 minute it still shows "Just now".

Fixes https://github.com/nextcloud/whiteboard/issues/857

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
