### PR TITLE
fix: tighten whiteboard collaboration CSP

### DIFF
--- a/lib/Listener/AddContentSecurityPolicyListener.php
+++ b/lib/Listener/AddContentSecurityPolicyListener.php
@@ -17,6 +17,8 @@ use OCP\Security\CSP\AddContentSecurityPolicyEvent;
 
 /** @template-implements IEventListener<Event|AddContentSecurityPolicyEvent> */
 class AddContentSecurityPolicyListener implements IEventListener {
+	private const EXCALIDRAW_LIBRARY_ORIGIN = 'https://libraries.excalidraw.com';
+
 	public function __construct(
 		private IRequest $request,
 		private ConfigService $configService,
@@ -29,36 +31,69 @@ class AddContentSecurityPolicyListener implements IEventListener {
 			return;
 		}
 
-		if (!$this->isPageLoad() || !$this->isWhiteboardPage()) {
-			return;
-		}
-
-		$domains = $this->configService->getCollabBackendCspConnectDomains();
-		if ($domains === []) {
+		if (!$this->isWhiteboardPage()) {
 			return;
 		}
 
 		$policy = new EmptyContentSecurityPolicy();
-		foreach ($domains as $domain) {
+		$policy->addAllowedWorkerSrcDomain('\'self\'');
+		if (!$this->configService->getDisableExternalLibraries()) {
+			$policy->addAllowedConnectDomain(self::EXCALIDRAW_LIBRARY_ORIGIN);
+		}
+
+		foreach ($this->configService->getCollabBackendCspConnectDomains() as $domain) {
 			$policy->addAllowedConnectDomain($domain);
 		}
 
 		$event->addPolicy($policy);
 	}
 
-	private function isPageLoad(): bool {
-		$scriptNameParts = explode('/', $this->request->getScriptName());
-		return end($scriptNameParts) === 'index.php';
-	}
-
 	private function isWhiteboardPage(): bool {
+		if ($this->request->getMethod() !== 'GET') {
+			return false;
+		}
+
 		$pathInfo = $this->request->getPathInfo();
 		if (!is_string($pathInfo)) {
 			return false;
 		}
 
-		return str_starts_with($pathInfo, '/apps/files')
-			|| str_starts_with($pathInfo, '/apps/whiteboard/recording')
-			|| str_starts_with($pathInfo, '/s/');
+		$pathInfo = $this->normalizePathInfo($pathInfo);
+
+		// The /apps/files prefix also covers non-page GET endpoints. Keep this
+		// listener scoped to page shells that can host Whiteboard instead of adding
+		// Whiteboard collaboration sources to Files API responses or service workers.
+		if ($this->pathMatches($pathInfo, '/apps/files/api')
+			|| $this->pathMatches($pathInfo, '/apps/files/preview-service-worker.js')) {
+			return false;
+		}
+
+		return $this->pathMatches($pathInfo, '/apps/files')
+			|| $this->pathMatches($pathInfo, '/apps/whiteboard/recording')
+			|| $this->pathMatches($pathInfo, '/apps/spreed')
+			|| $this->pathMatches($pathInfo, '/call')
+			|| $this->pathMatches($pathInfo, '/f')
+			|| $this->pathMatches($pathInfo, '/s');
+	}
+
+	private function normalizePathInfo(string $pathInfo): string {
+		$path = parse_url($pathInfo, PHP_URL_PATH);
+		if (is_string($path)) {
+			$pathInfo = $path;
+		}
+
+		if ($pathInfo === '/index.php') {
+			return '/';
+		}
+
+		if (str_starts_with($pathInfo, '/index.php/')) {
+			return substr($pathInfo, strlen('/index.php'));
+		}
+
+		return $pathInfo;
+	}
+
+	private function pathMatches(string $pathInfo, string $prefix): bool {
+		return $pathInfo === $prefix || str_starts_with($pathInfo, $prefix . '/');
 	}
 }

--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -83,7 +83,11 @@ final class ConfigService {
 			return [];
 		}
 
-		$host = $parts['host'];
+		$host = strtolower($parts['host']);
+		if (!$this->isValidCspHost($host)) {
+			return [];
+		}
+
 		$port = isset($parts['port']) ? ':' . $parts['port'] : '';
 		$origin = $scheme . '://' . $host . $port;
 
@@ -99,6 +103,27 @@ final class ConfigService {
 		}
 
 		return array_values(array_unique($domains));
+	}
+
+	private function isValidCspHost(string $host): bool {
+		if ($host === '' || strlen($host) > 255) {
+			return false;
+		}
+
+		if (str_starts_with($host, '[') || str_ends_with($host, ']')) {
+			if (!str_starts_with($host, '[') || !str_ends_with($host, ']')) {
+				return false;
+			}
+
+			return filter_var(substr($host, 1, -1), FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false;
+		}
+
+		if (filter_var($host, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) !== false) {
+			return true;
+		}
+
+		return preg_match('/^[a-z0-9._-]+$/', $host) === 1
+			&& !str_contains($host, '..');
 	}
 
 	private function trimUrl(string $url): string {

--- a/tests/Unit/Listener/AddContentSecurityPolicyListenerTest.php
+++ b/tests/Unit/Listener/AddContentSecurityPolicyListenerTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Whiteboard\Listener;
+
+use OC\Security\CSP\ContentSecurityPolicy;
+use OC\Security\CSP\ContentSecurityPolicyManager;
+use OCA\Whiteboard\Service\ConfigService;
+use OCP\AppFramework\Services\IAppConfig;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IConfig;
+use OCP\IRequest;
+use OCP\Security\CSP\AddContentSecurityPolicyEvent;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Test\TestCase;
+
+class AddContentSecurityPolicyListenerTest extends TestCase {
+	#[DataProvider('whiteboardPageProvider')]
+	public function testAddsCollaborationCspOnWhiteboardPages(string $pathInfo): void {
+		$policy = $this->handleRequest($pathInfo);
+
+		$this->assertContains('https://whiteboard.example.com:3002', $policy->getAllowedConnectDomains());
+		$this->assertContains('wss://whiteboard.example.com:3002', $policy->getAllowedConnectDomains());
+		$this->assertContains('https://libraries.excalidraw.com', $policy->getAllowedConnectDomains());
+		$this->assertContains('\'self\'', $policy->getAllowedWorkerSrcDomains());
+		$this->assertNotContains('*', $policy->getAllowedConnectDomains());
+		$this->assertNotContains('*', $policy->getAllowedWorkerSrcDomains());
+	}
+
+	public static function whiteboardPageProvider(): array {
+		return [
+			'files app' => ['/apps/files'],
+			'files app with index.php' => ['/index.php/apps/files/files/123?dir=/&openfile=true'],
+			'files direct editing' => ['/apps/files/directEditing/token'],
+			'direct file route' => ['/f/12345'],
+			'direct file route with index.php' => ['/index.php/f/12345'],
+			'public share route' => ['/s/shareToken'],
+			'public share route with index.php' => ['/index.php/s/shareToken'],
+			'talk app' => ['/apps/spreed'],
+			'talk room' => ['/apps/spreed/room/abc123'],
+			'talk room with index.php' => ['/index.php/apps/spreed/room/abc123'],
+			'talk call route' => ['/call/abc123'],
+			'talk call route with index.php' => ['/index.php/call/abc123'],
+			'recording route' => ['/apps/whiteboard/recording/123/alice'],
+		];
+	}
+
+	#[DataProvider('nonWhiteboardPageProvider')]
+	public function testDoesNotAddCollaborationCspOutsideWhiteboardPages(string $pathInfo, string $method = 'GET'): void {
+		$policy = $this->handleRequest($pathInfo, $method);
+
+		$this->assertNotContains('https://whiteboard.example.com:3002', $policy->getAllowedConnectDomains());
+		$this->assertNotContains('wss://whiteboard.example.com:3002', $policy->getAllowedConnectDomains());
+		$this->assertNotContains('https://libraries.excalidraw.com', $policy->getAllowedConnectDomains());
+		$this->assertNotContains('\'self\'', $policy->getAllowedWorkerSrcDomains());
+	}
+
+	public static function nonWhiteboardPageProvider(): array {
+		return [
+			'other app page' => ['/apps/dashboard'],
+			'files api' => ['/apps/files/api/v1/thumbnail/32/32/Photos/image.jpg'],
+			'files api with index.php' => ['/index.php/apps/files/api/v1/thumbnail/32/32/Photos/image.jpg'],
+			'files service worker route' => ['/apps/files/preview-service-worker.js'],
+			'files service worker route with index.php' => ['/index.php/apps/files/preview-service-worker.js'],
+			'whiteboard data api' => ['/apps/whiteboard/12345'],
+			'files post request' => ['/apps/files', 'POST'],
+			'talk post request' => ['/apps/spreed', 'POST'],
+			'files_external app is not files' => ['/apps/files_external'],
+		];
+	}
+
+	public function testAddsStaticSourcesEvenWithoutConfiguredBackend(): void {
+		$policy = $this->handleRequest('/apps/spreed/room/abc123', 'GET', '');
+
+		$this->assertContains('\'self\'', $policy->getAllowedWorkerSrcDomains());
+		$this->assertSame(['\'self\'', 'https://libraries.excalidraw.com'], $policy->getAllowedConnectDomains());
+	}
+
+	public function testDoesNotAllowExternalLibrariesWhenDisabled(): void {
+		$policy = $this->handleRequest('/apps/files', 'GET', '', true);
+
+		$this->assertSame(['\'self\''], $policy->getAllowedConnectDomains());
+	}
+
+	private function handleRequest(
+		string $pathInfo,
+		string $method = 'GET',
+		string $backendUrl = 'https://whiteboard.example.com:3002/socket.io/',
+		bool $disableExternalLibraries = false,
+	): ContentSecurityPolicy {
+		$request = $this->createMock(IRequest::class);
+		$request->method('getMethod')->willReturn($method);
+		$request->method('getPathInfo')->willReturn($pathInfo);
+
+		$listener = new AddContentSecurityPolicyListener(
+			$request,
+			$this->createConfigService($backendUrl, $disableExternalLibraries),
+		);
+
+		$dispatcher = $this->createMock(IEventDispatcher::class);
+		$policyManager = new ContentSecurityPolicyManager($dispatcher);
+
+		$listener->handle(new AddContentSecurityPolicyEvent($policyManager));
+
+		return $policyManager->getDefaultPolicy();
+	}
+
+	private function createConfigService(string $backendUrl, bool $disableExternalLibraries): ConfigService {
+		$appConfig = $this->createMock(IAppConfig::class);
+		$appConfig->method('getAppValueString')
+			->with('collabBackendUrl')
+			->willReturn($backendUrl);
+		$appConfig->method('getAppValueBool')
+			->with('disable_external_libraries')
+			->willReturn($disableExternalLibraries);
+
+		return new ConfigService($appConfig, $this->createMock(IConfig::class));
+	}
+}

--- a/tests/Unit/Service/ConfigServiceTest.php
+++ b/tests/Unit/Service/ConfigServiceTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Whiteboard\Service;
+
+use OCP\AppFramework\Services\IAppConfig;
+use OCP\IConfig;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Test\TestCase;
+
+class ConfigServiceTest extends TestCase {
+	#[DataProvider('backendCspDomainProvider')]
+	public function testCollabBackendCspConnectDomains(string $url, array $expected): void {
+		$service = $this->createService($url);
+
+		$this->assertSame($expected, $service->getCollabBackendCspConnectDomains());
+	}
+
+	public static function backendCspDomainProvider(): array {
+		return [
+			'https backend also allows wss' => [
+				'https://whiteboard.example.com/socket.io/',
+				['https://whiteboard.example.com', 'wss://whiteboard.example.com'],
+			],
+			'http backend with port also allows ws' => [
+				'http://whiteboard.local:3002/base/',
+				['http://whiteboard.local:3002', 'ws://whiteboard.local:3002'],
+			],
+			'wss backend also allows https' => [
+				'wss://whiteboard.example.com:8443/socket.io',
+				['wss://whiteboard.example.com:8443', 'https://whiteboard.example.com:8443'],
+			],
+			'ws backend also allows http' => [
+				'ws://127.0.0.1:3002/socket.io',
+				['ws://127.0.0.1:3002', 'http://127.0.0.1:3002'],
+			],
+			'ipv6 backend' => [
+				'https://[::1]:3002/socket.io',
+				['https://[::1]:3002', 'wss://[::1]:3002'],
+			],
+			'underscore backend host' => [
+				'https://whiteboard_backend.local:3002/socket.io',
+				['https://whiteboard_backend.local:3002', 'wss://whiteboard_backend.local:3002'],
+			],
+			'trailing dot fqdn backend host' => [
+				'https://whiteboard.example.com.:3002/socket.io',
+				['https://whiteboard.example.com.:3002', 'wss://whiteboard.example.com.:3002'],
+			],
+			'dash edge backend labels' => [
+				'https://-whiteboard.example-.local:3002/socket.io',
+				['https://-whiteboard.example-.local:3002', 'wss://-whiteboard.example-.local:3002'],
+			],
+		];
+	}
+
+	#[DataProvider('invalidBackendUrlProvider')]
+	public function testInvalidCollabBackendUrlsAreNotUsedForCsp(string $url): void {
+		$service = $this->createService($url);
+
+		$this->assertSame([], $service->getCollabBackendCspConnectDomains());
+	}
+
+	public static function invalidBackendUrlProvider(): array {
+		return [
+			'empty' => [''],
+			'missing scheme' => ['//whiteboard.example.com'],
+			'unsupported scheme' => ['ftp://whiteboard.example.com'],
+			'javascript scheme' => ['javascript:alert(1)'],
+			'host with csp delimiter' => ['https://whiteboard.example.com;script-src *'],
+			'host with quoted source injection' => ["https://whiteboard.example.com 'unsafe-eval'"],
+			'wildcard host' => ['https://*.example.com'],
+			'empty label' => ['https://whiteboard..example.com'],
+			'invalid ipv6 literal' => ['https://[not-ipv6]:3002'],
+		];
+	}
+
+	private function createService(string $backendUrl): ConfigService {
+		$appConfig = $this->createMock(IAppConfig::class);
+		$appConfig->method('getAppValueString')
+			->with('collabBackendUrl')
+			->willReturn($backendUrl);
+
+		return new ConfigService($appConfig, $this->createMock(IConfig::class));
+	}
+}

--- a/tests/integration/font-copy-config.spec.mjs
+++ b/tests/integration/font-copy-config.spec.mjs
@@ -1,0 +1,45 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { access, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { build } from 'vite'
+
+import createConfig from '../../vite.config.ts'
+
+describe('Excalidraw font assets', () => {
+	it('copies fonts to dist/fonts instead of preserving node_modules in the URL path', async () => {
+		const projectRoot = fileURLToPath(new URL('../..', import.meta.url))
+		const temporaryDirectory = await mkdtemp(join(tmpdir(), 'whiteboard-font-copy-'))
+		const entry = join(temporaryDirectory, 'entry.js')
+		const output = join(temporaryDirectory, 'output')
+
+		try {
+			await writeFile(entry, '')
+			const config = await createConfig({ command: 'build', mode: 'production' })
+			config.configFile = false
+			config.root = projectRoot
+			config.logLevel = 'silent'
+			config.build = {
+				...config.build,
+				emptyOutDir: true,
+				outDir: output,
+				rollupOptions: {
+					...config.build.rollupOptions,
+					input: { fontCopyTest: entry },
+				},
+			}
+			await build(config)
+
+			await expect(access(join(output, 'dist/fonts/Assistant/Assistant-Regular.woff2'))).resolves.toBeUndefined()
+			await expect(access(join(output, 'dist/node_modules'))).rejects.toThrow()
+		} finally {
+			await rm(temporaryDirectory, { recursive: true, force: true })
+		}
+	})
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -72,6 +72,7 @@ const AppConfig = createAppConfig({
 					{
 						src: EXCALIDRAW_FONTS_DIR,
 						dest: 'dist',
+						rename: { stripBase: 5 },
 					},
 				],
 			}),


### PR DESCRIPTION
## Summary
- Apply Whiteboard CSP only on page routes that can host Whiteboard, including Talk and /call pages.
- Add the configured collaboration backend HTTP(S) origin and matching WS(S) origin to connect-src without wildcards.
- Self-host Excalidraw fonts and fail the build if the CDN fallback rewrite stops matching.

## Fixed issues
Fixes #1250
Fixes #1222
Fixes #1215
Fixes #1198