### PR TITLE
test(e2e): target exact Votings button

### DIFF
--- a/playwright/e2e/voting.spec.ts
+++ b/playwright/e2e/voting.spec.ts
@@ -16,7 +16,7 @@ test('Create a voting and add it to the whiteboard', async ({ page }) => {
 
 	// Open the main menu and navigate to voting
 	await page.getByTestId('main-menu-trigger').click()
-	await page.getByRole('button', { name: /voting/i }).click()
+	await page.getByRole('button', { name: 'Votings', exact: true }).click()
 
 	// Start a new voting
 	await page.getByRole('button', { name: /start new voting/i }).click()


### PR DESCRIPTION
## What changed

Match the existing `Votings` button by its exact accessible name.

## Why

Nextcloud server PR #61658 changed Files-row accessible names. A board named `Voting ...` now also matches the loose `/voting/i` selector, so Playwright strict mode finds both the board button and the `Votings` action.

Using `menuitem` is not valid on current `main`; that role appears only with the unrelated Excalidraw update in #1161.

## Verification

- Production build passes on Node 24.
- The targeted voting E2E on Nextcloud master resolves and clicks the exact `Votings` action.
- The remaining test flow is unchanged.

Refs nextcloud/server#61658.