### PR TITLE
fix: await websocket initialization

### DIFF
--- a/tests/integration/multinode-redis.spec.mjs
+++ b/tests/integration/multinode-redis.spec.mjs
@@ -437,9 +437,11 @@ describe('Multi node websocket cluster with redis streams', () => {
 		viewerSocket.emit('join-room', roomID)
 		await waitFor(viewerSocket, 'sync-designate')
 
+		const presentationStarted = waitFor(presenterSocket, 'presentation-started')
+		const presentationNotice = waitFor(viewerSocket, 'user-started-presenting')
 		presenterSocket.emit('presentation-start', { fileId: roomID, userId: 'shutdown-presenter' })
-		await waitFor(presenterSocket, 'presentation-started')
-		await waitFor(viewerSocket, 'user-started-presenting')
+		await presentationStarted
+		await presentationNotice
 
 		const stoppedNotice = waitFor(viewerSocket, 'user-stopped-presenting')
 		await serverA.gracefulShutdown()

--- a/websocket_server/Services/ServerService.js
+++ b/websocket_server/Services/ServerService.js
@@ -80,7 +80,9 @@ export default class ServerService {
 		return serverType.createServer(serverOptions, app)
 	}
 
-	start() {
+	async start() {
+		await this.socketService.ready
+
 		return new Promise((resolve, reject) => {
 			this.server.listen(Config.PORT, Config.HOST, () => {
 				console.log(`Listening on interface ${Config.HOST} port: ${Config.PORT}`)

--- a/websocket_server/Services/SocketService.js
+++ b/websocket_server/Services/SocketService.js
@@ -134,7 +134,7 @@ export default class SocketService {
 			votingService: this.votingService,
 		})
 		this.clusterService.setSweepHandler(this.handleSweepResults.bind(this))
-		this.init()
+		this.ready = this.init()
 	}
 
 	createSocketServer(server) {


### PR DESCRIPTION
## What

- Wait for Redis and Socket.IO initialization before the HTTP server starts listening.
- Register presentation listeners before starting the cross-node event.

## Why

A quickly restarted server could accept a client before its socket handlers were ready, so `join-room` was lost. The presentation test could separately attach its viewer listener after the event had already arrived.

## Verification

- Multinode Redis tests passed 10 consecutive runs: 12/12 each
- Full Node tests passed: 38/38