### PR TITLE
chore(release): prepare 2.0.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.0.0-beta.2
+
+### Changed
+- Support Nextcloud 35 by @hweihwang [#1314](https://github.com/nextcloud/whiteboard/pull/1314)
+
+### Other
+- Update dependencies and translations
+
 ## 2.0.0-beta.1
 
 ### Added

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -23,7 +23,7 @@ The official whiteboard app for Nextcloud. It allows users to create and share w
 
 ]]>
 	</description>
-	<version>2.0.0-beta.1</version>
+	<version>2.0.0-beta.2</version>
 	<licence>agpl</licence>
 	<author>Julius Härtl</author>
 	<namespace>Whiteboard</namespace>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "whiteboard",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "whiteboard",
-      "version": "2.0.0-beta.1",
+      "version": "2.0.0-beta.2",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@excalidraw/mermaid-to-excalidraw": "^2.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "whiteboard",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "license": "AGPL-3.0-or-later",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## Summary

Prepare the Whiteboard **2.0.0-beta.2** pre-release on top of the Nextcloud 35 support work.

- `appinfo/info.xml`: `2.0.0-beta.1` → `2.0.0-beta.2`
- `package.json` / `package-lock.json`: version bump to match
- `CHANGELOG.md`: add `2.0.0-beta.2` section

Highlights since `2.0.0-beta.1`:

- Support Nextcloud 35 (#1314)
- Dependency and translation updates

This will be tagged `v2.0.0-beta.2` and published as a GitHub pre-release (beta channel only; the App Store only serves it to beta/daily/git instances, and the Docker image is published to the `beta` tag only).

## AI disclosure

This release preparation commit was created with AI assistance (`Assisted-by: OpenAI Codex:gpt-5.6-sol`). The version metadata and changelog were reviewed by a human maintainer before submission.